### PR TITLE
Updates

### DIFF
--- a/api.go
+++ b/api.go
@@ -17,7 +17,7 @@ func (m *CirconusMetrics) apiCall(reqMethod string, reqPath string, data []byte)
 	// default to SSL
 	proto := "https://"
 	// allow override with explict "http://" in ApiHost
-	if m.ApiHost[0:4] == "http" {
+	if m.ApiHost[0:5] == "http:" {
 		proto = ""
 	}
 

--- a/api.go
+++ b/api.go
@@ -15,8 +15,7 @@ func (m *CirconusMetrics) apiCall(reqMethod string, reqPath string, data []byte)
 
 	// default to SSL
 	proto := "https://"
-	// allow user to override with explict "http://" in ApiHost
-	// if that floats their boat...
+	// allow override with explict "http://" in ApiHost
 	if m.ApiHost[0:4] == "http" {
 		proto = ""
 	}
@@ -25,7 +24,7 @@ func (m *CirconusMetrics) apiCall(reqMethod string, reqPath string, data []byte)
 
 	req, err := retryablehttp.NewRequest(reqMethod, url, dataReader)
 	if err != nil {
-		return nil, fmt.Errorf("Error making API request to %s %+v", url, err)
+		return nil, fmt.Errorf("Error creating API request: %s %+v", url, err)
 	}
 	req.Header.Add("Accept", "application/json")
 	req.Header.Add("X-Circonus-Auth-Token", m.ApiToken)
@@ -39,7 +38,7 @@ func (m *CirconusMetrics) apiCall(reqMethod string, reqPath string, data []byte)
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("Error fetching %s: %s\n", url, err)
+		return nil, err
 	}
 
 	defer resp.Body.Close()

--- a/api.go
+++ b/api.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/go-retryablehttp"
 )
 
+// Call Circonus API
 func (m *CirconusMetrics) apiCall(reqMethod string, reqPath string, data []byte) ([]byte, error) {
 	dataReader := bytes.NewReader(data)
 

--- a/broker.go
+++ b/broker.go
@@ -14,6 +14,7 @@ func init() {
 	rand.Seed(time.Now().UnixNano())
 }
 
+// Get Broker to use when creating a check
 func (m *CirconusMetrics) getBroker() (*Broker, error) {
 	if m.BrokerGroupId != 0 {
 		broker, err := m.fetchBrokerById(m.BrokerGroupId)
@@ -32,6 +33,7 @@ func (m *CirconusMetrics) getBroker() (*Broker, error) {
 	return broker, nil
 }
 
+// Get CN of Broker associated with submission_url to satisfy no IP SANS in certs
 func (m *CirconusMetrics) getBrokerCN(broker *Broker, submissionUrl string) (string, error) {
 	u, err := url.Parse(submissionUrl)
 	if err != nil {
@@ -62,6 +64,8 @@ func (m *CirconusMetrics) getBrokerCN(broker *Broker, submissionUrl string) (str
 
 }
 
+// Select a broker for use when creating a check, if a specific broker
+// was not specified.
 func (m *CirconusMetrics) selectBroker() (*Broker, error) {
 	brokerList, err := m.fetchBrokerList()
 	if err != nil {
@@ -95,6 +99,7 @@ func (m *CirconusMetrics) selectBroker() (*Broker, error) {
 
 }
 
+// Verify broker supports the check type to be used
 func (m *CirconusMetrics) brokerSupportsCheckType(checkType string, details *BrokerDetail) bool {
 
 	for _, module := range details.Modules {
@@ -107,6 +112,7 @@ func (m *CirconusMetrics) brokerSupportsCheckType(checkType string, details *Bro
 
 }
 
+// Is the broker valid (active and supports check type)
 func (m *CirconusMetrics) isValidBroker(broker *Broker) bool {
 	valid := false
 	for _, detail := range broker.Details {

--- a/brokerapi.go
+++ b/brokerapi.go
@@ -28,11 +28,13 @@ type Broker struct {
 	Type      string         `json:"_type"`
 }
 
+// Use Circonus API to retrieve  a specific broker by Broker Group ID
 func (m *CirconusMetrics) fetchBrokerById(id int) (*Broker, error) {
 	cid := fmt.Sprintf("/v2/broker/%d", id)
 	return m.fetchBrokerByCid(cid)
 }
 
+// Use Circonus API to retreive a broker by CID
 func (m *CirconusMetrics) fetchBrokerByCid(cid string) (*Broker, error) {
 	result, err := m.apiCall("GET", cid, nil)
 	if err != nil {
@@ -48,6 +50,7 @@ func (m *CirconusMetrics) fetchBrokerByCid(cid string) (*Broker, error) {
 
 }
 
+// Use Circonus API to retreive a list of brokers
 func (m *CirconusMetrics) fetchBrokerList() ([]Broker, error) {
 	result, err := m.apiCall("GET", "/v2/broker", nil)
 	if err != nil {

--- a/cert.go
+++ b/cert.go
@@ -9,6 +9,7 @@ type CACert struct {
 	Contents string `json:"contents"`
 }
 
+// Load the CA cert for the broker designated by the submission url
 func (m *CirconusMetrics) loadCACert() {
 	if m.cert != nil {
 		return
@@ -34,6 +35,7 @@ func (m *CirconusMetrics) loadCACert() {
 	m.certPool.AppendCertsFromPEM(cert)
 }
 
+// Use the Circonus API to retrieve the CA certificate
 func (m *CirconusMetrics) fetchCert() ([]byte, error) {
 	response, err := m.apiCall("GET", "/v2/pki/ca.crt", nil)
 	if err != nil {
@@ -52,6 +54,7 @@ func (m *CirconusMetrics) fetchCert() ([]byte, error) {
 	return []byte(cadata.Contents), nil
 }
 
+// Default Circonus CA certificate
 var circonusCA []byte = []byte(`-----BEGIN CERTIFICATE-----
 MIID4zCCA0ygAwIBAgIJAMelf8skwVWPMA0GCSqGSIb3DQEBBQUAMIGoMQswCQYD
 VQQGEwJVUzERMA8GA1UECBMITWFyeWxhbmQxETAPBgNVBAcTCENvbHVtYmlhMRcw

--- a/check.go
+++ b/check.go
@@ -7,13 +7,13 @@ import (
 	"fmt"
 )
 
+// Initialize CirconusMetrics instance. Attempt to find a check otherwise create one.
 // use cases:
 //
 // check [bundle] by submission url
 // check [bundle] by *check* id (note, not check_bundle id)
 // check [bundle] by search
 // create check [bundle]
-
 func (m *CirconusMetrics) initializeTrap() error {
 	m.trapmu.Lock()
 	defer m.trapmu.Unlock()
@@ -114,6 +114,7 @@ func (m *CirconusMetrics) initializeTrap() error {
 	return nil
 }
 
+// Search for a check bundle given a predetermined set of criteria
 func (m *CirconusMetrics) checkBundleSearch(criteria string) (*CheckBundle, error) {
 	checkBundles, err := m.searchCheckBundles(criteria)
 	if err != nil {
@@ -122,7 +123,6 @@ func (m *CirconusMetrics) checkBundleSearch(criteria string) (*CheckBundle, erro
 
 	if len(checkBundles) == 0 {
 		return nil, nil // trigger creation of a new check
-		// return nil, fmt.Errorf("No checks found matching criteria %s", searchCriteria)
 	}
 
 	numActive := 0
@@ -140,9 +140,9 @@ func (m *CirconusMetrics) checkBundleSearch(criteria string) (*CheckBundle, erro
 	}
 
 	return &checkBundles[checkId], nil
-
 }
 
+// Create a new check to receive metrics
 func (m *CirconusMetrics) createNewCheck() (*CheckBundle, *Broker, error) {
 	checkSecret := m.CheckSecret
 	if checkSecret == "" {
@@ -187,6 +187,7 @@ func (m *CirconusMetrics) createNewCheck() (*CheckBundle, *Broker, error) {
 	return checkBundle, broker, nil
 }
 
+// Create a dynamic secret to use with a new check
 func makeSecret() (string, error) {
 	hash := sha256.New()
 	x := make([]byte, 2048)
@@ -197,8 +198,9 @@ func makeSecret() (string, error) {
 	return hex.EncodeToString(hash.Sum(nil))[0:16], nil
 }
 
+// Add new metrics to an existing check
 func (m *CirconusMetrics) addNewCheckMetrics(newMetrics map[string]*CheckBundleMetric) {
-	// only manage metrics checkBundle has been populated
+	// only manage metrics if checkBundle has been populated
 	if m.checkBundle == nil {
 		return
 	}

--- a/checkapi.go
+++ b/checkapi.go
@@ -24,11 +24,13 @@ type Check struct {
 	Details        CheckDetails `json:"_details"`
 }
 
+// Use Circonus API to retrieve a check by ID
 func (m *CirconusMetrics) fetchCheckById(id int) (*Check, error) {
 	cid := fmt.Sprintf("/check/%d", id)
 	return m.fetchCheckByCid(cid)
 }
 
+// Use Circonus API to retrieve a check by CID
 func (m *CirconusMetrics) fetchCheckByCid(cid string) (*Check, error) {
 	result, err := m.apiCall("GET", cid, nil)
 	if err != nil {
@@ -41,6 +43,7 @@ func (m *CirconusMetrics) fetchCheckByCid(cid string) (*Check, error) {
 	return check, nil
 }
 
+// Use Circonus API to retrieve a check by submission url
 func (m *CirconusMetrics) fetchCheckBySubmissionUrl(submissionUrl string) (*Check, error) {
 
 	u, err := url.Parse(submissionUrl)

--- a/checkbundleapi.go
+++ b/checkbundleapi.go
@@ -42,11 +42,13 @@ type CheckBundle struct {
 	Type               string              `json:"type"`
 }
 
+// Use Circonus API to retrieve a check bundle by ID
 func (m *CirconusMetrics) fetchCheckBundleById(id int) (*CheckBundle, error) {
 	cid := fmt.Sprintf("/check_bundle/%d", id)
 	return m.fetchCheckBundleByCid(cid)
 }
 
+// Use Circonus API to retrieve a check bundle by CID
 func (m *CirconusMetrics) fetchCheckBundleByCid(cid string) (*CheckBundle, error) {
 	result, err := m.apiCall("GET", cid, nil)
 	if err != nil {
@@ -59,6 +61,7 @@ func (m *CirconusMetrics) fetchCheckBundleByCid(cid string) (*CheckBundle, error
 	return checkBundle, nil
 }
 
+// Use Circonus API to search for a check bundle
 func (m *CirconusMetrics) searchCheckBundles(searchCriteria string) ([]CheckBundle, error) {
 	apiPath := fmt.Sprintf("/v2/check_bundle?search=%s", searchCriteria)
 
@@ -76,6 +79,7 @@ func (m *CirconusMetrics) searchCheckBundles(searchCriteria string) ([]CheckBund
 	return results, nil
 }
 
+// Use Circonus API to create a check bundle
 func (m *CirconusMetrics) createCheckBundle(config CheckBundle) (*CheckBundle, error) {
 	cfgJson, err := json.Marshal(config)
 	if err != nil {
@@ -96,6 +100,7 @@ func (m *CirconusMetrics) createCheckBundle(config CheckBundle) (*CheckBundle, e
 	return checkBundle, nil
 }
 
+// Use Circonus API to update a check bundle
 func (m *CirconusMetrics) updateCheckBundle(config *CheckBundle) (*CheckBundle, error) {
 	cfgJson, err := json.Marshal(config)
 	if err != nil {

--- a/circonus-gometrics.go
+++ b/circonus-gometrics.go
@@ -39,9 +39,10 @@ import (
 
 const (
 	// a few sensible defaults
-	defaultApiHost  = "api.circonus.com"
-	defaultApiApp   = "circonus-gometrics"
-	defaultInterval = 10 * time.Second
+	defaultApiHost             = "api.circonus.com"
+	defaultApiApp              = "circonus-gometrics"
+	defaultInterval            = 10 * time.Second
+	defaultMaxSubmissionUrlAge = 60 * time.Second
 )
 
 // a few words about: "BrokerGroupId"
@@ -77,15 +78,25 @@ type CirconusMetrics struct {
 	CheckSecret   string
 
 	Interval time.Duration
-	Log      *log.Logger
-	Debug    bool
+	// if the submission url returns errors
+	// this gates the amount of time to keep the current
+	// submission url before attempting to retrieve it
+	// again from the api
+	MaxSubmissionUrlAge time.Duration
+
+	Log   *log.Logger
+	Debug bool
 
 	// internals
-	ready   bool
-	trapUrl string
-	trapCN  string
-	trapSSL bool
-	trapmu  sync.Mutex
+	flushing bool
+	flushmu  sync.Mutex
+
+	ready          bool
+	trapUrl        string
+	trapCN         string
+	trapSSL        bool
+	trapLastUpdate time.Time
+	trapmu         sync.Mutex
 
 	certPool      *x509.CertPool
 	cert          []byte
@@ -118,23 +129,24 @@ func NewCirconusMetrics() *CirconusMetrics {
 	}
 
 	return &CirconusMetrics{
-		InstanceId:    fmt.Sprintf("%s:%s", hn, an),
-		SearchTag:     fmt.Sprintf("service:%s", an),
-		ApiHost:       defaultApiHost,
-		ApiApp:        defaultApiApp,
-		Interval:      defaultInterval,
-		Log:           log.New(ioutil.Discard, "", log.LstdFlags),
-		Debug:         false,
-		ready:         false,
-		trapUrl:       "",
-		activeMetrics: make(map[string]bool),
-		counters:      make(map[string]uint64),
-		counterFuncs:  make(map[string]func() uint64),
-		gauges:        make(map[string]int64),
-		gaugeFuncs:    make(map[string]func() int64),
-		histograms:    make(map[string]*Histogram),
-		certPool:      x509.NewCertPool(),
-		checkType:     "httptrap",
+		InstanceId:          fmt.Sprintf("%s:%s", hn, an),
+		SearchTag:           fmt.Sprintf("service:%s", an),
+		ApiHost:             defaultApiHost,
+		ApiApp:              defaultApiApp,
+		Interval:            defaultInterval,
+		MaxSubmissionUrlAge: defaultMaxSubmissionUrlAge,
+		Log:                 log.New(ioutil.Discard, "", log.LstdFlags),
+		Debug:               false,
+		ready:               false,
+		trapUrl:             "",
+		activeMetrics:       make(map[string]bool),
+		counters:            make(map[string]uint64),
+		counterFuncs:        make(map[string]func() uint64),
+		gauges:              make(map[string]int64),
+		gaugeFuncs:          make(map[string]func() int64),
+		histograms:          make(map[string]*Histogram),
+		certPool:            x509.NewCertPool(),
+		checkType:           "httptrap",
 	}
 
 }
@@ -164,13 +176,23 @@ func (m *CirconusMetrics) Start() error {
 
 // Flush metrics kicks off the process of sending metrics to Circonus
 func (m *CirconusMetrics) Flush() {
-	m.Log.Println("Flushing")
-	if !m.ready {
-		if err := m.initializeTrap(); err != nil {
-			m.Log.Printf("Unable to initialize check, NOT flushing metrics. %s\n", err)
-		}
+	if m.flushing {
+		m.Log.Println("Flush already active.")
 		return
 	}
+	m.flushmu.Lock()
+	m.flushing = true
+	m.flushmu.Unlock()
+
+	if !m.ready {
+		m.Log.Println("Initializing trap")
+		if err := m.initializeTrap(); err != nil {
+			m.Log.Printf("Unable to initialize check, NOT flushing metrics. %s\n", err)
+			return
+		}
+	}
+
+	m.Log.Println("Flushing")
 
 	// check for new metrics and enable them automatically
 	newMetrics := make(map[string]*CheckBundleMetric)
@@ -220,4 +242,8 @@ func (m *CirconusMetrics) Flush() {
 	}
 
 	m.submit(output, newMetrics)
+
+	m.flushmu.Lock()
+	m.flushing = false
+	m.flushmu.Unlock()
 }

--- a/circonus-gometrics.go
+++ b/circonus-gometrics.go
@@ -109,6 +109,7 @@ type CirconusMetrics struct {
 	hm         sync.Mutex
 }
 
+// return new CirconusMetrics instance
 func NewCirconusMetrics() *CirconusMetrics {
 	_, an := path.Split(os.Args[0])
 	hn, err := os.Hostname()
@@ -138,7 +139,10 @@ func NewCirconusMetrics() *CirconusMetrics {
 
 }
 
-// Start starts a perdiodic submission process of all metrics collected
+// Start initializes the CirconusMetrics instance based on
+// configuration settings and sets the httptrap check url to
+// which metrics should be sent. It then starts a perdiodic
+// submission process of all metrics collected.
 func (m *CirconusMetrics) Start() error {
 	if m.Debug {
 		m.Log = log.New(os.Stderr, "", log.LstdFlags)
@@ -158,6 +162,7 @@ func (m *CirconusMetrics) Start() error {
 	return nil
 }
 
+// Flush metrics kicks off the process of sending metrics to Circonus
 func (m *CirconusMetrics) Flush() {
 	m.Log.Println("Flushing")
 	if !m.ready {

--- a/counter.go
+++ b/counter.go
@@ -5,32 +5,38 @@ package circonusgometrics
 // Use a counter to derive rates (e.g., record total number of requests, derive
 // requests per second).
 
+// Increment counter by 1
 func (m *CirconusMetrics) Increment(metric string) {
 	m.Add(metric, 1)
 }
 
+// Increment counter by a supplied value
 func (m *CirconusMetrics) IncrementByValue(metric string, val uint64) {
 	m.Add(metric, val)
 }
 
+// Increment counter by a supplied value
 func (m *CirconusMetrics) Add(metric string, val uint64) {
 	m.cm.Lock()
 	defer m.cm.Unlock()
 	m.counters[metric] += val
 }
 
+// Remove a counter
 func (m *CirconusMetrics) RemoveCounter(metric string) {
 	m.cm.Lock()
 	defer m.cm.Unlock()
 	delete(m.counters, metric)
 }
 
+// Set a counter to a function [called at flush interval]
 func (m *CirconusMetrics) SetCounterFunc(metric string, fn func() uint64) {
 	m.cfm.Lock()
 	defer m.cfm.Unlock()
 	m.counterFuncs[metric] = fn
 }
 
+// Remove a counter function
 func (m *CirconusMetrics) RemoveCounterFunc(metric string) {
 	m.cfm.Lock()
 	defer m.cfm.Unlock()

--- a/gauge.go
+++ b/gauge.go
@@ -5,28 +5,33 @@ package circonusgometrics
 // Use a gauge to track metrics which increase and decrease (e.g., amount of
 // free memory).
 
+// Set a gauge to a value
 func (m *CirconusMetrics) Gauge(metric string, val int64) {
 	m.SetGauge(metric, val)
 }
 
+// Set a gauge to a value
 func (m *CirconusMetrics) SetGauge(metric string, val int64) {
 	m.gm.Lock()
 	defer m.gm.Unlock()
 	m.gauges[metric] = val
 }
 
+// Remove a gauge
 func (m *CirconusMetrics) RemoveGauge(metric string) {
 	m.gm.Lock()
 	defer m.gm.Unlock()
 	delete(m.gauges, metric)
 }
 
+// Set a gauge to a function [called at flush interval]
 func (m *CirconusMetrics) SetGaugeFunc(metric string, fn func() int64) {
 	m.gfm.Lock()
 	defer m.gfm.Unlock()
 	m.gaugeFuncs[metric] = fn
 }
 
+// Remove a gauge function
 func (m *CirconusMetrics) RemoveGaugeFunc(metric string) {
 	m.gfm.Lock()
 	defer m.gfm.Unlock()

--- a/histogram.go
+++ b/histogram.go
@@ -13,14 +13,17 @@ type Histogram struct {
 	rw   sync.RWMutex
 }
 
+// Add a value to a histogram
 func (m *CirconusMetrics) Timing(metric string, val float64) {
 	m.SetHistogramValue(metric, val)
 }
 
+// Add a value to a histogram
 func (m *CirconusMetrics) RecordValue(metric string, val float64) {
 	m.SetHistogramValue(metric, val)
 }
 
+// Add a value to a histogram
 func (m *CirconusMetrics) SetHistogramValue(metric string, val float64) {
 	m.NewHistogram(metric)
 
@@ -30,6 +33,7 @@ func (m *CirconusMetrics) SetHistogramValue(metric string, val float64) {
 	m.histograms[metric].hist.RecordValue(val)
 }
 
+// Create a new histogram (and receive a pointer to it)
 func (m *CirconusMetrics) NewHistogram(metric string) *Histogram {
 	m.hm.Lock()
 	defer m.hm.Unlock()
@@ -48,18 +52,19 @@ func (m *CirconusMetrics) NewHistogram(metric string) *Histogram {
 	return hist
 }
 
+// Remove a histogram
 func (m *CirconusMetrics) RemoveHistogram(metric string) {
 	m.hm.Lock()
 	defer m.hm.Unlock()
 	delete(m.histograms, metric)
 }
 
-// Name returns the name of the histogram
+// Name returns the name from a histogram instance
 func (h *Histogram) Name() string {
 	return h.name
 }
 
-// RecordValue records the given value
+// RecordValue records the given value to a histogram instance
 func (h *Histogram) RecordValue(v float64) {
 	h.rw.Lock()
 	defer h.rw.Unlock()

--- a/submit.go
+++ b/submit.go
@@ -5,8 +5,8 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io/ioutil"
+	"log"
 	"net"
 	"net/http"
 	"strconv"
@@ -16,7 +16,6 @@ import (
 )
 
 func (m *CirconusMetrics) submit(output map[string]interface{}, newMetrics map[string]*CheckBundleMetric) {
-	// short-circuit, don't manage metrics if there is no check bundle
 	if len(newMetrics) > 0 {
 		m.addNewCheckMetrics(newMetrics)
 	}
@@ -30,10 +29,10 @@ func (m *CirconusMetrics) submit(output map[string]interface{}, newMetrics map[s
 	numStats, err := m.trapCall(str)
 	if err != nil {
 		m.Log.Printf("[ERROR] %+v\n", err)
+		return
 	}
-	if m.Debug {
-		m.Log.Printf("%d stats sent to %s\n", numStats, m.trapUrl)
-	}
+
+	m.Log.Printf("%d stats sent to %s\n", numStats, m.trapUrl)
 }
 
 func (m *CirconusMetrics) trapCall(payload []byte) (int, error) {
@@ -84,9 +83,21 @@ func (m *CirconusMetrics) trapCall(payload []byte) (int, error) {
 	client.RetryMax = 3
 	client.Logger = m.Log
 
+	attempts := -1
+	client.RequestLogHook = func(logger *log.Logger, req *http.Request, retryNumber int) {
+		attempts = retryNumber
+	}
+
 	resp, err := client.Do(req)
 	if err != nil {
-		fmt.Printf("client.Do error %#v", err)
+		if attempts == client.RetryMax {
+			if time.Since(m.trapLastUpdate) >= m.MaxSubmissionUrlAge {
+				m.trapmu.Lock()
+				defer m.trapmu.Unlock()
+				m.ready = false
+				m.trapUrl = ""
+			}
+		}
 		return 0, err
 	}
 

--- a/submit.go
+++ b/submit.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -85,6 +86,7 @@ func (m *CirconusMetrics) trapCall(payload []byte) (int, error) {
 
 	resp, err := client.Do(req)
 	if err != nil {
+		fmt.Printf("client.Do error %#v", err)
 		return 0, err
 	}
 

--- a/util.go
+++ b/util.go
@@ -15,13 +15,16 @@ func (m *CirconusMetrics) Reset() {
 	m.gm.Lock()
 	defer m.gm.Unlock()
 
+	m.gfm.Lock()
+	defer m.gfm.Unlock()
+
 	m.hm.Lock()
 	defer m.hm.Unlock()
 
 	m.counters = make(map[string]uint64)
 	m.counterFuncs = make(map[string]func() uint64)
-	//	m.gauges = make(map[string]func() int64)
 	m.gauges = make(map[string]int64)
+	m.gaugeFuncs = make(map[string]func() int64)
 	m.histograms = make(map[string]*Histogram)
 }
 


### PR DESCRIPTION
* Add comments to methods
* Add MaxSubmissionUrlAge setting for refreshing submission url when submits start failing
* Add flushing flag so that only one flush is running at a time (avoid stomping on retries and failed submits triggering a submission url refresh)
* Cleaned up some comments and error messages
* If SubmissionUrl configuration option is used, after successfully retrieving the associated check object. Save the check id and blank the original submission url so that if the broker changes via the UI a new submission url can still be retrieved (via the check id).