### PR TITLE
return error in correct format

### DIFF
--- a/checkbundleapi.go
+++ b/checkbundleapi.go
@@ -67,7 +67,7 @@ func (m *CirconusMetrics) searchCheckBundles(searchCriteria string) ([]CheckBund
 
 	response, err := m.apiCall("GET", apiPath, nil)
 	if err != nil {
-		return nil, fmt.Errorf("[ERROR] API call error %+v", response)
+		return nil, fmt.Errorf("[ERROR] API call error %+v", err)
 	}
 
 	var results []CheckBundle


### PR DESCRIPTION
not returning correct error message when search attempted with no api token.