### PR TITLE
Add ForceMetricActivation option, default to FALSE

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,11 @@ func main() {
 	cmc.CheckManager.Check.MaxURLAge = "5m"
 	// custom display name for check, default: "InstanceId /cgm"
 	cmc.CheckManager.Check.DisplayName = ""
+    // force metric activation - if a metric has been disabled via the UI
+	// the default behavior is to *not* re-activate the metric; this setting
+	// overrides the behavior and will re-activate the metric when it is
+	// encountered. "(true|false)", default "false"
+	cmc.CheckManager.Check.ForceMetricActivation = "false"
 
 	// Broker configuration options
 	//

--- a/checkmgr/metrics.go
+++ b/checkmgr/metrics.go
@@ -6,8 +6,23 @@ import (
 
 // IsMetricActive checks whether a given metric name is currently active(enabled)
 func (cm *CheckManager) IsMetricActive(name string) bool {
-	_, ok := cm.activeMetrics[name]
-	return ok
+	active, _ := cm.availableMetrics[name]
+	return active
+}
+
+// ActivateMetric determines if a given metric should be activated
+func (cm *CheckManager) ActivateMetric(name string) bool {
+	active, exists := cm.availableMetrics[name]
+
+	if !exists {
+		return true
+	}
+
+	if !active && cm.forceMetricActivation {
+		return true
+	}
+
+	return false
 }
 
 // AddNewMetrics updates a check bundle with new metrics
@@ -52,11 +67,9 @@ func (cm *CheckManager) AddNewMetrics(newMetrics map[string]*api.CheckBundleMetr
 
 // inventoryMetrics creates list of active metrics in check bundle
 func (cm *CheckManager) inventoryMetrics() {
-	activeMetrics := make(map[string]bool)
+	availableMetrics := make(map[string]bool)
 	for _, metric := range cm.checkBundle.Metrics {
-		if metric.Status == "active" {
-			activeMetrics[metric.Name] = true
-		}
+		availableMetrics[metric.Name] = metric.Status == "active"
 	}
-	cm.activeMetrics = activeMetrics
+	cm.availableMetrics = availableMetrics
 }

--- a/checkmgr/metrics_test.go
+++ b/checkmgr/metrics_test.go
@@ -11,7 +11,7 @@ func TestIsMetricActive(t *testing.T) {
 
 	cm := &CheckManager{}
 
-	cm.activeMetrics = map[string]bool{
+	cm.availableMetrics = map[string]bool{
 		"foo": true,
 	}
 
@@ -27,7 +27,7 @@ func TestIsMetricActive(t *testing.T) {
 }
 
 func TestInventoryMetrics(t *testing.T) {
-	t.Log("Testing correct return from IsMetricActive")
+	t.Log("Testing correct return from InventoryMetrics")
 
 	cm := &CheckManager{}
 	cm.checkBundle = &api.CheckBundle{}
@@ -39,7 +39,7 @@ func TestInventoryMetrics(t *testing.T) {
 		},
 	}
 
-	cm.activeMetrics = make(map[string]bool)
+	cm.availableMetrics = make(map[string]bool)
 
 	t.Log("Testing for 'foo', foo not in list")
 	if cm.IsMetricActive("foo") {
@@ -57,5 +57,64 @@ func TestInventoryMetrics(t *testing.T) {
 	t.Log("Testing for 'bar', bar not in list")
 	if cm.IsMetricActive("bar") {
 		t.Error("Expected false")
+	}
+}
+
+func TestActivateMetric(t *testing.T) {
+	t.Log("Testing correct return from ActivateMetric")
+
+	cm := &CheckManager{}
+	cm.checkBundle = &api.CheckBundle{}
+	cm.checkBundle.Metrics = []api.CheckBundleMetric{
+		api.CheckBundleMetric{
+			Name:   "foo",
+			Type:   "numeric",
+			Status: "active",
+		},
+	}
+
+	cm.availableMetrics = make(map[string]bool)
+	cm.forceMetricActivation = false
+
+	t.Log("Testing for 'foo', foo not in list")
+	if !cm.ActivateMetric("foo") {
+		t.Error("Expected true")
+	}
+
+	t.Log("Inventory metrics in check bundle")
+	cm.inventoryMetrics()
+
+	t.Log("Testing for 'foo', foo in list")
+	if cm.ActivateMetric("foo") {
+		t.Error("Expected false")
+	}
+
+	cm.checkBundle.Metrics = []api.CheckBundleMetric{
+		api.CheckBundleMetric{
+			Name:   "bar",
+			Type:   "numeric",
+			Status: "available",
+		},
+	}
+
+	t.Log("Testing for 'bar', bar not in list")
+	if !cm.ActivateMetric("bar") {
+		t.Error("Expected true")
+	}
+
+	t.Log("Inventory metrics in check bundle")
+	cm.inventoryMetrics()
+
+	t.Log("Testing for 'bar', bar in list[false]")
+	if cm.ActivateMetric("bar") {
+		t.Error("Expected false")
+	}
+
+	t.Log("Change forceMetricActivation to true")
+	cm.forceMetricActivation = true
+
+	t.Log("Testing for 'bar', bar in list[false]")
+	if !cm.ActivateMetric("bar") {
+		t.Error("Expected true")
 	}
 }

--- a/circonus-gometrics.go
+++ b/circonus-gometrics.go
@@ -169,57 +169,73 @@ func (m *CirconusMetrics) Flush() {
 	counters, gauges, histograms, text := m.snapshot()
 	output := make(map[string]interface{})
 	for name, value := range counters {
-		output[name] = map[string]interface{}{
-			"_type":  "n",
-			"_value": value,
-		}
-		if !m.check.IsMetricActive(name) {
+		send := m.check.IsMetricActive(name)
+		if !send && m.check.ActivateMetric(name) {
+			send = true
 			newMetrics[name] = &api.CheckBundleMetric{
 				Name:   name,
 				Type:   "numeric",
 				Status: "active",
+			}
+		}
+		if send {
+			output[name] = map[string]interface{}{
+				"_type":  "n",
+				"_value": value,
 			}
 		}
 	}
 
 	for name, value := range gauges {
-		output[name] = map[string]interface{}{
-			"_type":  "n",
-			"_value": value,
-		}
-		if !m.check.IsMetricActive(name) {
+		send := m.check.IsMetricActive(name)
+		if !send && m.check.ActivateMetric(name) {
+			send = true
 			newMetrics[name] = &api.CheckBundleMetric{
 				Name:   name,
 				Type:   "numeric",
 				Status: "active",
 			}
 		}
+		if send {
+			output[name] = map[string]interface{}{
+				"_type":  "n",
+				"_value": value,
+			}
+		}
 	}
 
 	for name, value := range histograms {
-		output[name] = map[string]interface{}{
-			"_type":  "n",
-			"_value": value.DecStrings(),
-		}
-		if !m.check.IsMetricActive(name) {
+		send := m.check.IsMetricActive(name)
+		if !send && m.check.ActivateMetric(name) {
+			send = true
 			newMetrics[name] = &api.CheckBundleMetric{
 				Name:   name,
 				Type:   "histogram",
 				Status: "active",
 			}
 		}
+		if send {
+			output[name] = map[string]interface{}{
+				"_type":  "n",
+				"_value": value.DecStrings(),
+			}
+		}
 	}
 
 	for name, value := range text {
-		output[name] = map[string]interface{}{
-			"_type":  "s",
-			"_value": value,
-		}
-		if !m.check.IsMetricActive(name) {
+		send := m.check.IsMetricActive(name)
+		if !send && m.check.ActivateMetric(name) {
+			send = true
 			newMetrics[name] = &api.CheckBundleMetric{
 				Name:   name,
 				Type:   "text",
 				Status: "active",
+			}
+		}
+		if send {
+			output[name] = map[string]interface{}{
+				"_type":  "s",
+				"_value": value,
 			}
 		}
 	}


### PR DESCRIPTION
Allow user to control whether metrics which already exist are re-activated.

ForceMetricActivation = "false" DEFAULT - if a metric exists with a status other than "active", it is not made active.

ForceMetricActivation = "true" - if a metric exists with a status other than "active", it is made active.

Regardless of setting, if a metric does not currently exists, it is added and made active.