### PR TITLE
fixes and changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ func main() {
 
     // Reset histogram metrics after each submission, default: "true"
     // Change to "false" to retain (and continue submitting) the last value.
-    // cmc.ResetHistogramss = "true"
+    // cmc.ResetHistograms = "true"
 
     // Reset text metrics after each submission, default: "true"
     // Change to "false" to retain (and continue submitting) the last value.

--- a/README.md
+++ b/README.md
@@ -30,8 +30,10 @@ func main() {
 
 	// Interval at which metrics are submitted to Circonus, default: 10 seconds
 	cmc.Interval = "10s" // 10 seconds
+
 	// Enable debug messages, default: false
 	cmc.Debug = false
+
 	// Send debug messages to specific log.Logger instance
 	// default: if debug stderr, else, discard
 	//cmc.CheckManager.Log = ...
@@ -55,8 +57,10 @@ func main() {
 	//
 	// Pre-existing httptrap check submission_url
 	cmc.CheckManager.Check.SubmissionURL = os.Getenv("CIRCONUS_SUBMISION_URL")
+
 	// Pre-existing httptrap check id (check not check bundle)
 	cmc.CheckManager.Check.ID = ""
+
 	// if neither a submission url nor check id are provided, an attempt will be made to find an existing
 	// httptrap check by using the circonus api to search for a check matching the following criteria:
 	//      an active check,
@@ -69,23 +73,32 @@ func main() {
 	// note: for a persistent instance that is ephemeral or transient where metric continuity is
 	//       desired set this explicitly so that the current hostname will not be used.
 	cmc.CheckManager.Check.InstanceID = ""
-	// Search tag - a specific tag which, when coupled with the instanceId serves to identify the
-	// origin and/or grouping of the metrics. Multiple tags may be used, separate with comma.
-    // (e.g. service:consul,service_role:server)
-	// default: service:application name (e.g. service:consul)
+
+	// Search tag - specific tag(s) used in conjunction with isntanceId to search for an
+    // existing check. comma separated string of tags (spaces will be removed, no commas
+    // in tag elements).
+	// default: service:application name (e.g. service:consul service:nomad etc.)
 	cmc.CheckManager.Check.SearchTag = ""
+
 	// Check secret, default: generated when a check needs to be created
 	cmc.CheckManager.Check.Secret = ""
-	// Check tags, array of strings, additional tags to add to a new check, default: none
-	//cmc.CheckManager.Check.Tags = []string{"category:tagname"}
+
+	// Additional tag(s) to add when *creating* a check. comma separated string
+    // of tags (spaces will be removed, no commas in tag elements).
+    // (e.g. group:abc or service_role:agent,group:xyz).
+    // default: none
+	cmc.CheckManager.Check.Tags = ""
+
 	// max amount of time to to hold on to a submission url
 	// when a given submission fails (due to retries) if the
 	// time the url was last updated is > than this, the trap
 	// url will be refreshed (e.g. if the broker is changed
 	// in the UI) default 5 minutes
 	cmc.CheckManager.Check.MaxURLAge = "5m"
+
 	// custom display name for check, default: "InstanceId /cgm"
 	cmc.CheckManager.Check.DisplayName = ""
+
     // force metric activation - if a metric has been disabled via the UI
 	// the default behavior is to *not* re-activate the metric; this setting
 	// overrides the behavior and will re-activate the metric when it is
@@ -98,15 +111,19 @@ func main() {
 	// Circonus default if no enterprise brokers are available.
 	// default: only used if set
 	cmc.CheckManager.Broker.ID = ""
-	// used to select a broker with the same tag (e.g. can be used to dictate that a broker
-	// serving a specific location should be used. "dc:sfo", "location:new_york", "zone:us-west")
-	// if more than one broker has the tag, one will be selected randomly from the resulting list
-	// default: not used unless != ""
+
+	// used to select a broker with the same tag(s) (e.g. can be used to dictate that a broker
+	// serving a specific location should be used. "dc:sfo", "loc:nyc,dc:nyc01", "zone:us-west")
+	// if more than one broker has the tag(s), one will be selected randomly from the resulting
+    // list. comma separated string of tags (spaces will be removed, no commas in tag elements).
+	// default: none
 	cmc.CheckManager.Broker.SelectTag = ""
+
 	// longest time to wait for a broker connection (if latency is > the broker will
 	// be considered invalid and not available for selection.), default: 500 milliseconds
 	cmc.CheckManager.Broker.MaxResponseTime = "500ms"
-	// if broker Id or SelectTag are not specified, a broker will be selected randomly
+
+	// note: if broker Id or SelectTag are not specified, a broker will be selected randomly
 	// from the list of brokers available to the api token. enterprise brokers take precedence
 	// viable brokers are "active", have the "httptrap" module enabled, are reachable and respond
 	// within MaxResponseTime.

--- a/README.md
+++ b/README.md
@@ -24,19 +24,37 @@ import (
 
 func main() {
 
-	log.Println("Configuring cgm")
+    logger := log.New(os.Stdout, "", log.LstdFlags)
+
+	logger.Println("Configuring cgm")
 
 	cmc := &cgm.Config{}
 
 	// Interval at which metrics are submitted to Circonus, default: 10 seconds
-	cmc.Interval = "10s" // 10 seconds
+	// cmc.Interval = "10s" // 10 seconds
 
 	// Enable debug messages, default: false
-	cmc.Debug = false
+	cmc.Debug = true
 
 	// Send debug messages to specific log.Logger instance
 	// default: if debug stderr, else, discard
-	//cmc.CheckManager.Log = ...
+	cmc.Log = logger
+
+    // Reset counter metrics after each submission, default: "true"
+    // Change to "false" to retain (and continue submitting) the last value.
+    // cmc.ResetCounters = "true"
+
+    // Reset gauge metrics after each submission, default: "true"
+    // Change to "false" to retain (and continue submitting) the last value.
+    // cmc.ResetGauges = "true"
+
+    // Reset histogram metrics after each submission, default: "true"
+    // Change to "false" to retain (and continue submitting) the last value.
+    // cmc.ResetHistogramss = "true"
+
+    // Reset text metrics after each submission, default: "true"
+    // Change to "false" to retain (and continue submitting) the last value.
+    // cmc.ResetText = "true"
 
 	// Circonus API configuration options
 	//
@@ -55,11 +73,11 @@ func main() {
 	// otherwise: if an applicable check is NOT specified or found, an
 	//            attempt will be made to automatically create one
 	//
-	// Pre-existing httptrap check submission_url
+	// Submission URL for an existing [httptrap] check
 	cmc.CheckManager.Check.SubmissionURL = os.Getenv("CIRCONUS_SUBMISION_URL")
 
-	// Pre-existing httptrap check id (check not check bundle)
-	cmc.CheckManager.Check.ID = ""
+	// ID of an existing [httptrap] check (note: check id not check bundle id)
+	cmc.CheckManager.Check.ID = os.Getenv("CIRCONUS_CHECK_ID")
 
 	// if neither a submission url nor check id are provided, an attempt will be made to find an existing
 	// httptrap check by using the circonus api to search for a check matching the following criteria:
@@ -72,63 +90,63 @@ func main() {
 	// default: 'hostname':'program name'
 	// note: for a persistent instance that is ephemeral or transient where metric continuity is
 	//       desired set this explicitly so that the current hostname will not be used.
-	cmc.CheckManager.Check.InstanceID = ""
+	// cmc.CheckManager.Check.InstanceID = ""
 
 	// Search tag - specific tag(s) used in conjunction with isntanceId to search for an
     // existing check. comma separated string of tags (spaces will be removed, no commas
     // in tag elements).
 	// default: service:application name (e.g. service:consul service:nomad etc.)
-	cmc.CheckManager.Check.SearchTag = ""
+	// cmc.CheckManager.Check.SearchTag = ""
 
 	// Check secret, default: generated when a check needs to be created
-	cmc.CheckManager.Check.Secret = ""
+	// cmc.CheckManager.Check.Secret = ""
 
 	// Additional tag(s) to add when *creating* a check. comma separated string
     // of tags (spaces will be removed, no commas in tag elements).
     // (e.g. group:abc or service_role:agent,group:xyz).
     // default: none
-	cmc.CheckManager.Check.Tags = ""
+	// cmc.CheckManager.Check.Tags = ""
 
 	// max amount of time to to hold on to a submission url
 	// when a given submission fails (due to retries) if the
 	// time the url was last updated is > than this, the trap
 	// url will be refreshed (e.g. if the broker is changed
 	// in the UI) default 5 minutes
-	cmc.CheckManager.Check.MaxURLAge = "5m"
+	// cmc.CheckManager.Check.MaxURLAge = "5m"
 
 	// custom display name for check, default: "InstanceId /cgm"
-	cmc.CheckManager.Check.DisplayName = ""
+	// cmc.CheckManager.Check.DisplayName = ""
 
     // force metric activation - if a metric has been disabled via the UI
 	// the default behavior is to *not* re-activate the metric; this setting
 	// overrides the behavior and will re-activate the metric when it is
 	// encountered. "(true|false)", default "false"
-	cmc.CheckManager.Check.ForceMetricActivation = "false"
+	// cmc.CheckManager.Check.ForceMetricActivation = "false"
 
 	// Broker configuration options
 	//
 	// Broker ID of specific broker to use, default: random enterprise broker or
 	// Circonus default if no enterprise brokers are available.
 	// default: only used if set
-	cmc.CheckManager.Broker.ID = ""
+	// cmc.CheckManager.Broker.ID = ""
 
 	// used to select a broker with the same tag(s) (e.g. can be used to dictate that a broker
 	// serving a specific location should be used. "dc:sfo", "loc:nyc,dc:nyc01", "zone:us-west")
 	// if more than one broker has the tag(s), one will be selected randomly from the resulting
     // list. comma separated string of tags (spaces will be removed, no commas in tag elements).
 	// default: none
-	cmc.CheckManager.Broker.SelectTag = ""
+	// cmc.CheckManager.Broker.SelectTag = ""
 
 	// longest time to wait for a broker connection (if latency is > the broker will
 	// be considered invalid and not available for selection.), default: 500 milliseconds
-	cmc.CheckManager.Broker.MaxResponseTime = "500ms"
+	// cmc.CheckManager.Broker.MaxResponseTime = "500ms"
 
 	// note: if broker Id or SelectTag are not specified, a broker will be selected randomly
 	// from the list of brokers available to the api token. enterprise brokers take precedence
 	// viable brokers are "active", have the "httptrap" module enabled, are reachable and respond
 	// within MaxResponseTime.
 
-	log.Println("Creating new cgm instance")
+	logger.Println("Creating new cgm instance")
 
 	metrics, err := cgm.NewCirconusMetrics(cmc)
 	if err != nil {
@@ -138,23 +156,44 @@ func main() {
 	src := rand.NewSource(time.Now().UnixNano())
 	rnd := rand.New(src)
 
-	log.Println("Starting cgm internal auto-flush timer")
+	logger.Println("Starting cgm internal auto-flush timer")
 	metrics.Start()
 
-	log.Println("Starting to send metrics")
+    logger.Println("Adding ctrl-c trap")
+	c := make(chan os.Signal, 2)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-c
+		logger.Println("Received CTRL-C, flushing outstanding metrics before exit")
+		metrics.Flush()
+		os.Exit(0)
+	}()
 
-	// number of "sets" of metrics to send (a minute worth)
+    // Add metric tags (append to any existing tags on specified metric)
+    metrics.AddMetricTags("foo", []string{"cgm:test"})
+    metrics.AddMetricTags("baz", []string{"cgm:test"})
+
+	logger.Println("Starting to send metrics")
+
+	// number of "sets" of metrics to send
 	max := 60
 
 	for i := 1; i < max; i++ {
-		log.Printf("\tmetric set %d of %d", i, 60)
-		metrics.Timing("ding", rnd.Float64()*10)
-		metrics.Increment("dong")
-		metrics.Gauge("dang", 10)
-		time.Sleep(1000 * time.Millisecond)
+		logger.Printf("\tmetric set %d of %d", i, 60)
+
+		metrics.Timing("foo", rnd.Float64()*10)
+		metrics.Increment("bar")
+		metrics.Gauge("baz", 10)
+
+        if i == 35 {
+            // Set metric tags (overwrite current tags on specified metric)
+            metrics.SetMetricTags("baz", []string{"cgm:reset_test", "cgm:test2"})
+        }
+
+        time.Sleep(time.Second)
 	}
 
-	log.Println("Flushing any outstanding metrics manually")
+	logger.Println("Flushing any outstanding metrics manually")
 	metrics.Flush()
 
 }

--- a/api/api.go
+++ b/api/api.go
@@ -24,9 +24,9 @@ const (
 	// a few sensible defaults
 	defaultAPIURL = "https://api.circonus.com/v2"
 	defaultAPIApp = "circonus-gometrics"
-	minRetryWait  = 100 * time.Millisecond
-	maxRetryWait  = 250 * time.Millisecond
-	maxRetries    = 5
+	minRetryWait  = 1 * time.Second
+	maxRetryWait  = 15 * time.Second
+	maxRetries    = 4 // equating to 1 + maxRetries total attempts
 )
 
 // TokenKeyType - Circonus API Token key

--- a/api/api.go
+++ b/api/api.go
@@ -47,8 +47,11 @@ type URLType string
 // SearchQueryType search query
 type SearchQueryType string
 
-// SearchTagType search/select tag type
-type SearchTagType string
+// SearchFilterType search filter
+type SearchFilterType string
+
+// TagType search/select/custom tag(s) type
+type TagType []string
 
 // Config options for Circonus API
 type Config struct {

--- a/api/api.go
+++ b/api/api.go
@@ -201,15 +201,15 @@ func (a *API) apiCall(reqMethod string, reqPath string, data []byte) ([]byte, er
 	resp, err := client.Do(req)
 	if err != nil {
 		if lastHTTPError != nil {
-			return nil, fmt.Errorf("[ERROR] fetching: %+v %+v", err, lastHTTPError)
+			return nil, lastHTTPError
 		}
-		return nil, fmt.Errorf("[ERROR] fetching %s: %+v", reqURL, err)
+		return nil, fmt.Errorf("[ERROR] %s: %+v", reqURL, err)
 	}
 
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("[ERROR] reading body %+v", err)
+		return nil, fmt.Errorf("[ERROR] reading response %+v", err)
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -83,7 +83,7 @@ func TestApiCall(t *testing.T) {
 		t.Errorf("Expected error, got '%+v'", resp)
 	}
 
-	expected := fmt.Sprintf("[ERROR] fetching: GET %s/retrytest giving up after 4 attempts - last HTTP error: 500 blah blah blah\n", server.URL)
+	expected := fmt.Sprintf("[ERROR] fetching: GET %s/retrytest giving up after 6 attempts - last HTTP error: 500 blah blah blah\n", server.URL)
 	if err.Error() != expected {
 		t.Errorf("Expected\n'%s'\ngot\n'%s'\n", expected, err)
 	}

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -83,7 +83,7 @@ func TestApiCall(t *testing.T) {
 		t.Errorf("Expected error, got '%+v'", resp)
 	}
 
-	expected := fmt.Sprintf("[ERROR] fetching: GET %s/retrytest giving up after 6 attempts - last HTTP error: 500 blah blah blah\n", server.URL)
+	expected := fmt.Sprintf("[ERROR] fetching: GET %s/retrytest giving up after 5 attempts - last HTTP error: 500 blah blah blah\n", server.URL)
 	if err.Error() != expected {
 		t.Errorf("Expected\n'%s'\ngot\n'%s'\n", expected, err)
 	}

--- a/api/broker.go
+++ b/api/broker.go
@@ -7,6 +7,7 @@ package api
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 )
 
 // BrokerDetail instance attributes
@@ -55,8 +56,8 @@ func (a *API) FetchBrokerByCID(cid CIDType) (*Broker, error) {
 }
 
 // FetchBrokerListByTag return list of brokers with a specific tag
-func (a *API) FetchBrokerListByTag(searchTag SearchTagType) ([]Broker, error) {
-	query := SearchQueryType(fmt.Sprintf("f__tags_has=%s", searchTag))
+func (a *API) FetchBrokerListByTag(searchTag TagType) ([]Broker, error) {
+	query := SearchQueryType(fmt.Sprintf("f__tags_has=%s", strings.Replace(strings.Join(searchTag, ","), ",", "&f__tags_has=", -1)))
 	return a.BrokerSearch(query)
 }
 

--- a/api/broker_test.go
+++ b/api/broker_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"reflect"
 	"strconv"
+	"strings"
 	"testing"
 )
 
@@ -65,7 +66,7 @@ func TestFetchBrokerByID(t *testing.T) {
 	t.Logf("Broker returned %s %s", broker.Name, broker.Cid)
 }
 
-func TestFetchBrokerListByTag(t *testing.T) {
+func TestFetchBrokerListByTag1(t *testing.T) {
 	if os.Getenv("CIRCONUS_API_TOKEN") == "" {
 		t.Skip("skipping test; $CIRCONUS_API_TOKEN not set")
 	}
@@ -87,7 +88,7 @@ func TestFetchBrokerListByTag(t *testing.T) {
 		t.Fatal("Invalid broker tag (empty)")
 	}
 
-	selectTag := SearchTagType(tag)
+	selectTag := strings.Split(strings.Replace(tag, " ", "", -1), ",")
 
 	brokers, err := apih.FetchBrokerListByTag(selectTag)
 	if err != nil {
@@ -98,6 +99,52 @@ func TestFetchBrokerListByTag(t *testing.T) {
 	expectedType := "[]api.Broker"
 	if actualType.String() != expectedType {
 		t.Errorf("Expected %s, got %s", expectedType, actualType.String())
+	}
+
+	if len(brokers) < 1 {
+		t.Fatalf("Expected at least 1 broker returned, recieved %d", len(brokers))
+	}
+
+	t.Logf("%d brokers returned", len(brokers))
+}
+
+func TestFetchBrokerListByTag2(t *testing.T) {
+	if os.Getenv("CIRCONUS_API_TOKEN") == "" {
+		t.Skip("skipping test; $CIRCONUS_API_TOKEN not set")
+	}
+	if os.Getenv("CIRC_API_TEST_BROKER_MULTI_TAG") == "" {
+		t.Skip("skipping test; $CIRC_API_TEST_BROKER_MULTI_TAG not set")
+	}
+
+	t.Log("Testing correct return from API call")
+
+	ac := &Config{}
+	ac.TokenKey = os.Getenv("CIRCONUS_API_TOKEN")
+	apih, err := NewAPI(ac)
+	if err != nil {
+		t.Errorf("Expected no error, got '%v'", err)
+	}
+
+	tag := os.Getenv("CIRC_API_TEST_BROKER_MULTI_TAG")
+	if tag == "" {
+		t.Fatal("Invalid broker tag (empty)")
+	}
+
+	selectTag := strings.Split(strings.Replace(tag, " ", "", -1), ",")
+
+	brokers, err := apih.FetchBrokerListByTag(selectTag)
+	if err != nil {
+		t.Fatalf("Expected no error, got '%v'", err)
+	}
+
+	actualType := reflect.TypeOf(brokers)
+	expectedType := "[]api.Broker"
+	if actualType.String() != expectedType {
+		t.Errorf("Expected %s, got %s", expectedType, actualType.String())
+	}
+
+	if len(brokers) < 1 {
+		t.Fatalf("Expected at least 1 broker returned, recieved %d", len(brokers))
 	}
 
 	t.Logf("%d brokers returned", len(brokers))

--- a/api/check.go
+++ b/api/check.go
@@ -69,9 +69,9 @@ func (a *API) FetchCheckBySubmissionURL(submissionURL URLType) (*Check, error) {
 	}
 	uuid := pathParts[0]
 
-	query := SearchQueryType(fmt.Sprintf("f__check_uuid=%s", uuid))
+	filter := SearchFilterType(fmt.Sprintf("f__check_uuid=%s", uuid))
 
-	checks, err := a.CheckSearch(query)
+	checks, err := a.CheckFilterSearch(filter)
 	if err != nil {
 		return nil, err
 	}
@@ -98,11 +98,28 @@ func (a *API) FetchCheckBySubmissionURL(submissionURL URLType) (*Check, error) {
 
 }
 
-// CheckSearch returns a list of checks matching a query/filter
+// CheckSearch returns a list of checks matching a search query
 func (a *API) CheckSearch(query SearchQueryType) ([]Check, error) {
-	queryURL := fmt.Sprintf("/check?%s", string(query))
+	queryURL := fmt.Sprintf("/check?search=%s", string(query))
 
 	result, err := a.Get(queryURL)
+	if err != nil {
+		return nil, err
+	}
+
+	var checks []Check
+	if err := json.Unmarshal(result, &checks); err != nil {
+		return nil, err
+	}
+
+	return checks, nil
+}
+
+// CheckFilterSearch returns a list of checks matching a filter
+func (a *API) CheckFilterSearch(filter SearchFilterType) ([]Check, error) {
+	filterURL := fmt.Sprintf("/check?%s", string(filter))
+
+	result, err := a.Get(filterURL)
 	if err != nil {
 		return nil, err
 	}

--- a/api/check_test.go
+++ b/api/check_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"reflect"
 	"strconv"
+	"strings"
 	"testing"
 )
 
@@ -71,8 +72,8 @@ func TestFetchCheckByID2(t *testing.T) {
 		t.Skip("skipping test; $CIRCONUS_API_TOKEN not set")
 	}
 
-	if os.Getenv("CIRCONUS_DELETED_CHECK_ID") == "" {
-		t.Skip("skipping test; $CIRCONUS_DELETED_CHECK_ID not set")
+	if os.Getenv("CIRC_API_TEST_DELETED_CHECK_ID") == "" {
+		t.Skip("skipping test; $CIRC_API_TEST_DELETED_CHECK_ID not set")
 	}
 
 	t.Log("Testing correct return from API call with DELETED check ID")
@@ -84,7 +85,7 @@ func TestFetchCheckByID2(t *testing.T) {
 		t.Errorf("Expected no error, got '%v'", err)
 	}
 
-	cid := os.Getenv("CIRCONUS_DELETED_CHECK_ID")
+	cid := os.Getenv("CIRC_API_TEST_DELETED_CHECK_ID")
 	if cid == "" {
 		t.Fatal("Invalid check id (empty)")
 	}
@@ -146,4 +147,134 @@ func TestFetchCheckBySubmissionURL(t *testing.T) {
 	}
 
 	t.Logf("Check returned %s %s", check.Cid, check.Details.SubmissionURL)
+}
+
+func TestCheckSearch1(t *testing.T) {
+	if os.Getenv("CIRCONUS_API_TOKEN") == "" {
+		t.Skip("skipping test; $CIRCONUS_API_TOKEN not set")
+	}
+	if os.Getenv("CIRC_API_TEST_CHECK_TAG") == "" {
+		t.Skip("skipping test; $CIRC_API_TEST_CHECK_TAG not set")
+	}
+
+	t.Log("Testing correct return from API call")
+
+	ac := &Config{}
+	ac.TokenKey = os.Getenv("CIRCONUS_API_TOKEN")
+
+	apih, err := NewAPI(ac)
+	if err != nil {
+		t.Errorf("Expected no error, got '%v'", err)
+	}
+
+	tag := os.Getenv("CIRC_API_TEST_CHECK_TAG")
+	if tag == "" {
+		t.Fatal("Invalid check search tag (empty)")
+	}
+
+	searchQuery := SearchQueryType(fmt.Sprintf("(active:1)(tags:%s)", tag))
+
+	checks, err := apih.CheckSearch(searchQuery)
+	if err != nil {
+		t.Fatalf("Expected no error, got '%v'", err)
+	}
+
+	actualType := reflect.TypeOf(checks)
+	expectedType := "[]api.Check"
+	if actualType.String() != expectedType {
+		t.Errorf("Expected %s, got %s", expectedType, actualType.String())
+	}
+
+	if len(checks) < 1 {
+		t.Fatalf("Expected at least 1 check returned, recieved %d", len(checks))
+	}
+
+	t.Logf("%d checks returned", len(checks))
+
+}
+
+func TestCheckSearch2(t *testing.T) {
+	if os.Getenv("CIRCONUS_API_TOKEN") == "" {
+		t.Skip("skipping test; $CIRCONUS_API_TOKEN not set")
+	}
+	if os.Getenv("CIRC_API_TEST_CHECK_MULTI_TAG") == "" {
+		t.Skip("skipping test; $CIRC_API_TEST_CHECK_MULTI_TAG not set")
+	}
+
+	t.Log("Testing correct return from API call")
+
+	ac := &Config{}
+	ac.TokenKey = os.Getenv("CIRCONUS_API_TOKEN")
+
+	apih, err := NewAPI(ac)
+	if err != nil {
+		t.Errorf("Expected no error, got '%v'", err)
+	}
+
+	tags := strings.Split(strings.Replace(os.Getenv("CIRC_API_TEST_CHECK_MULTI_TAG"), " ", "", -1), ",")
+	if len(tags) == 0 {
+		t.Fatal("Invalid check search tags (empty)")
+	}
+
+	searchQuery := SearchQueryType(fmt.Sprintf("(active:1)(tags:%s)", strings.Join(tags, ",")))
+
+	checks, err := apih.CheckSearch(searchQuery)
+	if err != nil {
+		t.Fatalf("Expected no error, got '%v'", err)
+	}
+
+	actualType := reflect.TypeOf(checks)
+	expectedType := "[]api.Check"
+	if actualType.String() != expectedType {
+		t.Errorf("Expected %s, got %s", expectedType, actualType.String())
+	}
+
+	if len(checks) < 1 {
+		t.Fatalf("Expected at least 1 check returned, recieved %d", len(checks))
+	}
+
+	t.Logf("%d checks returned", len(checks))
+
+}
+
+func TestCheckFileterSearch(t *testing.T) {
+	if os.Getenv("CIRCONUS_API_TOKEN") == "" {
+		t.Skip("skipping test; $CIRCONUS_API_TOKEN not set")
+	}
+	if os.Getenv("CIRC_API_TEST_CHECK_FILTER") == "" {
+		t.Skip("skipping test; $CIRC_API_TEST_CHECK_FILTER not set")
+	}
+
+	t.Log("Testing correct return from API call")
+
+	ac := &Config{}
+	ac.TokenKey = os.Getenv("CIRCONUS_API_TOKEN")
+
+	apih, err := NewAPI(ac)
+	if err != nil {
+		t.Errorf("Expected no error, got '%v'", err)
+	}
+
+	filter := os.Getenv("CIRC_API_TEST_CHECK_FILTER")
+	if filter == "" {
+		t.Fatal("Invalid check search filter (empty)")
+	}
+
+	checks, err := apih.CheckFilterSearch(SearchFilterType(filter))
+	if err != nil {
+		t.Fatalf("Expected no error, got '%v'", err)
+	}
+
+	actualType := reflect.TypeOf(checks)
+	expectedType := "[]api.Check"
+	if actualType.String() != expectedType {
+		t.Errorf("Expected %s, got %s", expectedType, actualType.String())
+	}
+
+	if len(checks) < 1 {
+		t.Fatalf("Expected at least 1 check returned, recieved %d", len(checks))
+	}
+
+	t.Logf("%d checks returned", len(checks))
+
 }

--- a/api/checkbundle.go
+++ b/api/checkbundle.go
@@ -25,10 +25,11 @@ type CheckBundleConfig struct {
 
 // CheckBundleMetric individual metric configuration
 type CheckBundleMetric struct {
-	Name   string `json:"name"`
-	Type   string `json:"type"`
-	Units  string `json:"units"`
-	Status string `json:"status"`
+	Name   string   `json:"name"`
+	Type   string   `json:"type"`
+	Units  string   `json:"units"`
+	Status string   `json:"status"`
+	Tags   []string `json:"tags"`
 }
 
 // CheckBundle definition
@@ -116,7 +117,7 @@ func (a *API) CreateCheckBundle(config CheckBundle) (*CheckBundle, error) {
 // UpdateCheckBundle updates a check bundle configuration
 func (a *API) UpdateCheckBundle(config *CheckBundle) (*CheckBundle, error) {
 	if a.Debug {
-		a.Log.Printf("[DEBUG] Updating check bundle with new metrics.")
+		a.Log.Printf("[DEBUG] Updating check bundle.")
 	}
 
 	cfgJSON, err := json.Marshal(config)

--- a/checkmgr/broker.go
+++ b/checkmgr/broker.go
@@ -79,7 +79,7 @@ func (cm *CheckManager) selectBroker() (*api.Broker, error) {
 	var brokerList []api.Broker
 	var err error
 
-	if cm.brokerSelectTag != "" {
+	if len(cm.brokerSelectTag) > 0 {
 		brokerList, err = cm.apih.FetchBrokerListByTag(cm.brokerSelectTag)
 		if err != nil {
 			return nil, err

--- a/checkmgr/check.go
+++ b/checkmgr/check.go
@@ -43,16 +43,17 @@ func (cm *CheckManager) UpdateCheck(newMetrics map[string]*api.CheckBundleMetric
 	}
 
 	if cm.forceCheckUpdate {
-		cm.cbmu.Lock()
 
 		newCheckBundle, err := cm.apih.UpdateCheckBundle(cm.checkBundle)
 		if err != nil {
-			cm.Log.Printf("[ERROR] updating check bundle with new metrics %v", err)
+			cm.Log.Printf("[ERROR] updating check bundle %v", err)
 			return
 		}
 
 		cm.forceCheckUpdate = false
+		cm.cbmu.Lock()
 		cm.checkBundle = newCheckBundle
+		cm.cbmu.Unlock()
 		cm.inventoryMetrics()
 
 		cm.cbmu.Unlock()

--- a/checkmgr/check.go
+++ b/checkmgr/check.go
@@ -17,6 +17,49 @@ import (
 	"github.com/circonus-labs/circonus-gometrics/api"
 )
 
+// UpdateCheck determines if the check needs to be updated (new metrics, tags, etc.)
+func (cm *CheckManager) UpdateCheck(newMetrics map[string]*api.CheckBundleMetric) {
+	// only if check manager is enabled
+	if !cm.enabled {
+		return
+	}
+
+	// only if checkBundle has been populated
+	if cm.checkBundle == nil {
+		return
+	}
+
+	cm.addNewMetrics(newMetrics)
+
+	if len(cm.metricTags) > 0 {
+		for metricName, metricTags := range cm.metricTags {
+			// note: if a tag has been added (queued) for a metric which never gets sent
+			//       the tags will be discarded. (setting tags does not *create* metrics.)
+			cm.AddMetricTags(metricName, metricTags, false)
+			cm.mtmu.Lock()
+			delete(cm.metricTags, metricName)
+			cm.mtmu.Unlock()
+		}
+	}
+
+	if cm.forceCheckUpdate {
+		cm.cbmu.Lock()
+
+		newCheckBundle, err := cm.apih.UpdateCheckBundle(cm.checkBundle)
+		if err != nil {
+			cm.Log.Printf("[ERROR] updating check bundle with new metrics %v", err)
+			return
+		}
+
+		cm.forceCheckUpdate = false
+		cm.checkBundle = newCheckBundle
+		cm.inventoryMetrics()
+
+		cm.cbmu.Unlock()
+	}
+
+}
+
 // Initialize CirconusMetrics instance. Attempt to find a check otherwise create one.
 // use cases:
 //

--- a/checkmgr/check.go
+++ b/checkmgr/check.go
@@ -86,7 +86,7 @@ func (cm *CheckManager) initializeTrapURL() error {
 	} else {
 		searchCriteria := fmt.Sprintf(
 			"(active:1)(host:\"%s\")(type:\"%s\")(tags:%s)",
-			cm.checkInstanceID, cm.checkType, cm.checkSearchTag)
+			cm.checkInstanceID, cm.checkType, strings.Join(cm.checkSearchTag, ","))
 		checkBundle, err = cm.checkBundleSearch(searchCriteria)
 		if err != nil {
 			return err
@@ -204,7 +204,7 @@ func (cm *CheckManager) createNewCheck() (*api.CheckBundle, *api.Broker, error) 
 		Notes:       "",
 		Period:      60,
 		Status:      statusActive,
-		Tags:        append([]string{string(cm.checkSearchTag)}, cm.checkTags...),
+		Tags:        append(cm.checkSearchTag, cm.checkTags...),
 		Target:      string(cm.checkInstanceID),
 		Timeout:     10,
 		Type:        string(cm.checkType),

--- a/checkmgr/checkmgr.go
+++ b/checkmgr/checkmgr.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"path"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -58,7 +59,7 @@ type CheckConfig struct {
 	// used to search for a check to use
 	// used as check.target when creating a check
 	InstanceID string
-	// unique check searching tag
+	// unique check searching tag (or tags)
 	// used to search for a check to use (combined with instanceid)
 	// used as a regular tag when creating a check
 	SearchTag string
@@ -68,7 +69,7 @@ type CheckConfig struct {
 	Secret string
 	// additional tags to add to a check (when creating a check)
 	// these tags will not be added to an existing check
-	Tags []string
+	Tags string
 	// max amount of time to to hold on to a submission url
 	// when a given submission fails (due to retries) if the
 	// time the url was last updated is > than this, the trap
@@ -87,8 +88,8 @@ type CheckConfig struct {
 type BrokerConfig struct {
 	// a specific broker id (numeric portion of cid)
 	ID string
-	// a tag that can be used to select 1-n brokers from which to select
-	// when creating a new check (e.g. datacenter:abc)
+	// one or more tags used to select 1-n brokers from which to select
+	// when creating a new check (e.g. datacenter:abc or loc:dfw,dc:abc)
 	SelectTag string
 	// for a broker to be considered viable it must respond to a
 	// connection attempt within this amount of time e.g. 200ms, 2s, 1m
@@ -118,7 +119,7 @@ type CheckInstanceIDType string
 type CheckSecretType string
 
 // CheckTagsType check tags
-type CheckTagsType []string
+type CheckTagsType string
 
 // CheckDisplayNameType check display name
 type CheckDisplayNameType string
@@ -137,16 +138,16 @@ type CheckManager struct {
 	checkType             CheckTypeType
 	checkID               api.IDType
 	checkInstanceID       CheckInstanceIDType
-	checkSearchTag        api.SearchTagType
+	checkSearchTag        api.TagType
 	checkSecret           CheckSecretType
-	checkTags             CheckTagsType
+	checkTags             api.TagType
 	checkSubmissionURL    api.URLType
 	checkDisplayName      CheckDisplayNameType
 	forceMetricActivation bool
 
 	// broker
 	brokerID              api.IDType
-	brokerSelectTag       api.SearchTagType
+	brokerSelectTag       api.TagType
 	brokerMaxResponseTime time.Duration
 
 	// state
@@ -233,9 +234,9 @@ func NewCheckManager(cfg *Config) (*CheckManager, error) {
 
 	cm.checkInstanceID = CheckInstanceIDType(cfg.Check.InstanceID)
 	cm.checkDisplayName = CheckDisplayNameType(cfg.Check.DisplayName)
-	cm.checkSearchTag = api.SearchTagType(cfg.Check.SearchTag)
+	cm.checkSearchTag = strings.Split(strings.Replace(cfg.Check.SearchTag, " ", "", -1), ",")
 	cm.checkSecret = CheckSecretType(cfg.Check.Secret)
-	cm.checkTags = cfg.Check.Tags
+	cm.checkTags = strings.Split(strings.Replace(cfg.Check.Tags, " ", "", -1), ",")
 
 	fma := defaultForceMetricActivation
 	if cfg.Check.ForceMetricActivation != "" {
@@ -256,8 +257,8 @@ func NewCheckManager(cfg *Config) (*CheckManager, error) {
 		cm.checkInstanceID = CheckInstanceIDType(fmt.Sprintf("%s:%s", hn, an))
 	}
 
-	if cm.checkSearchTag == "" {
-		cm.checkSearchTag = api.SearchTagType(fmt.Sprintf("service:%s", an))
+	if len(cm.checkSearchTag) == 0 {
+		cm.checkSearchTag = []string{fmt.Sprintf("service:%s", an)}
 	}
 
 	if cm.checkDisplayName == "" {
@@ -286,7 +287,7 @@ func NewCheckManager(cfg *Config) (*CheckManager, error) {
 	}
 	cm.brokerID = api.IDType(id)
 
-	cm.brokerSelectTag = api.SearchTagType(cfg.Broker.SelectTag)
+	cm.brokerSelectTag = strings.Split(strings.Replace(cfg.Broker.SelectTag, " ", "", -1), ",")
 
 	dur = cfg.Broker.MaxResponseTime
 	if dur == "" {

--- a/checkmgr/checkmgr.go
+++ b/checkmgr/checkmgr.go
@@ -234,9 +234,7 @@ func NewCheckManager(cfg *Config) (*CheckManager, error) {
 
 	cm.checkInstanceID = CheckInstanceIDType(cfg.Check.InstanceID)
 	cm.checkDisplayName = CheckDisplayNameType(cfg.Check.DisplayName)
-	cm.checkSearchTag = strings.Split(strings.Replace(cfg.Check.SearchTag, " ", "", -1), ",")
 	cm.checkSecret = CheckSecretType(cfg.Check.Secret)
-	cm.checkTags = strings.Split(strings.Replace(cfg.Check.Tags, " ", "", -1), ",")
 
 	fma := defaultForceMetricActivation
 	if cfg.Check.ForceMetricActivation != "" {
@@ -257,8 +255,14 @@ func NewCheckManager(cfg *Config) (*CheckManager, error) {
 		cm.checkInstanceID = CheckInstanceIDType(fmt.Sprintf("%s:%s", hn, an))
 	}
 
-	if len(cm.checkSearchTag) == 0 {
+	if cfg.Check.SearchTag == "" {
 		cm.checkSearchTag = []string{fmt.Sprintf("service:%s", an)}
+	} else {
+		cm.checkSearchTag = strings.Split(strings.Replace(cfg.Check.SearchTag, " ", "", -1), ",")
+	}
+
+	if cfg.Check.Tags != "" {
+		cm.checkTags = strings.Split(strings.Replace(cfg.Check.Tags, " ", "", -1), ",")
 	}
 
 	if cm.checkDisplayName == "" {
@@ -287,7 +291,9 @@ func NewCheckManager(cfg *Config) (*CheckManager, error) {
 	}
 	cm.brokerID = api.IDType(id)
 
-	cm.brokerSelectTag = strings.Split(strings.Replace(cfg.Broker.SelectTag, " ", "", -1), ",")
+	if cfg.Broker.SelectTag != "" {
+		cm.brokerSelectTag = strings.Split(strings.Replace(cfg.Broker.SelectTag, " ", "", -1), ",")
+	}
 
 	dur = cfg.Broker.MaxResponseTime
 	if dur == "" {

--- a/checkmgr/metrics.go
+++ b/checkmgr/metrics.go
@@ -29,44 +29,107 @@ func (cm *CheckManager) ActivateMetric(name string) bool {
 	return false
 }
 
-// AddNewMetrics updates a check bundle with new metrics
-func (cm *CheckManager) AddNewMetrics(newMetrics map[string]*api.CheckBundleMetric) {
-	// only if check manager is enabled
-	if !cm.enabled {
-		return
+// AddMetricTags updates check bundle metrics with tags
+func (cm *CheckManager) AddMetricTags(metricName string, tags []string, appendTags bool) bool {
+	tagsUpdated := false
+
+	if len(tags) == 0 {
+		return tagsUpdated
 	}
 
-	// only if checkBundle has been populated
-	if cm.checkBundle == nil {
-		return
+	metricFound := false
+
+	for metricIdx, metric := range cm.checkBundle.Metrics {
+		if metric.Name == metricName {
+			metricFound = true
+			numNewTags := countNewTags(metric.Tags, tags)
+
+			if numNewTags == 0 {
+				if appendTags {
+					break // no new tags to add
+				} else if len(metric.Tags) == len(tags) {
+					break // no new tags and old/new same length
+				}
+			}
+
+			cm.cbmu.Lock()
+
+			if appendTags {
+				metric.Tags = append(metric.Tags, tags...)
+			} else {
+				metric.Tags = tags
+			}
+
+			cm.checkBundle.Metrics[metricIdx] = metric
+			tagsUpdated = true
+
+			cm.cbmu.Unlock()
+		}
 	}
 
-	newCheckBundle := cm.checkBundle
-	numCurrMetrics := len(newCheckBundle.Metrics)
+	if tagsUpdated {
+		if cm.Debug {
+			action := "Set"
+			if appendTags {
+				action = "Added"
+			}
+			cm.Log.Printf("[DEBUG] %s metric tag(s) %s %v\n", action, metricName, tags)
+		}
+		cm.cbmu.Lock()
+		cm.forceCheckUpdate = true
+		cm.cbmu.Unlock()
+	} else {
+		if !metricFound {
+			if _, exists := cm.metricTags[metricName]; !exists {
+				if cm.Debug {
+					cm.Log.Printf("[DEBUG] Queing metric tag(s) %s %v\n", metricName, tags)
+				}
+				// queue the tags, the metric is new (e.g. not in the check yet)
+				cm.mtmu.Lock()
+				cm.metricTags[metricName] = append(cm.metricTags[metricName], tags...)
+				cm.mtmu.Unlock()
+			}
+		}
+	}
+
+	return tagsUpdated
+}
+
+// addNewMetrics updates a check bundle with new metrics
+func (cm *CheckManager) addNewMetrics(newMetrics map[string]*api.CheckBundleMetric) bool {
+	updatedCheckBundle := false
+
+	if cm.checkBundle == nil || len(newMetrics) == 0 {
+		return updatedCheckBundle
+	}
+
+	cm.cbmu.Lock()
+
+	numCurrMetrics := len(cm.checkBundle.Metrics)
 	numNewMetrics := len(newMetrics)
 
-	if numCurrMetrics+numNewMetrics >= cap(newCheckBundle.Metrics) {
+	if numCurrMetrics+numNewMetrics >= cap(cm.checkBundle.Metrics) {
 		nm := make([]api.CheckBundleMetric, numCurrMetrics+numNewMetrics)
-		copy(nm, newCheckBundle.Metrics)
-		newCheckBundle.Metrics = nm
+		copy(nm, cm.checkBundle.Metrics)
+		cm.checkBundle.Metrics = nm
 	}
 
-	newCheckBundle.Metrics = newCheckBundle.Metrics[0 : numCurrMetrics+numNewMetrics]
+	cm.checkBundle.Metrics = cm.checkBundle.Metrics[0 : numCurrMetrics+numNewMetrics]
 
 	i := 0
 	for _, metric := range newMetrics {
-		newCheckBundle.Metrics[numCurrMetrics+i] = *metric
+		cm.checkBundle.Metrics[numCurrMetrics+i] = *metric
 		i++
+		updatedCheckBundle = true
 	}
 
-	checkBundle, err := cm.apih.UpdateCheckBundle(newCheckBundle)
-	if err != nil {
-		cm.Log.Printf("[ERROR] updating check bundle with new metrics %v", err)
-		return
+	if updatedCheckBundle {
+		cm.forceCheckUpdate = true
 	}
 
-	cm.checkBundle = checkBundle
-	cm.inventoryMetrics()
+	cm.cbmu.Unlock()
+
+	return updatedCheckBundle
 }
 
 // inventoryMetrics creates list of active metrics in check bundle
@@ -76,4 +139,32 @@ func (cm *CheckManager) inventoryMetrics() {
 		availableMetrics[metric.Name] = metric.Status == "active"
 	}
 	cm.availableMetrics = availableMetrics
+}
+
+// countNewTags returns a count of new tags which do not exist in the current list of tags
+func countNewTags(currTags []string, newTags []string) int {
+	if len(newTags) == 0 {
+		return 0
+	}
+
+	if len(currTags) == 0 {
+		return len(newTags)
+	}
+
+	newTagCount := 0
+
+	for _, newTag := range newTags {
+		found := false
+		for _, currTag := range currTags {
+			if newTag == currTag {
+				found = true
+				break
+			}
+		}
+		if !found {
+			newTagCount++
+		}
+	}
+
+	return newTagCount
 }

--- a/checkmgr/metrics.go
+++ b/checkmgr/metrics.go
@@ -52,18 +52,17 @@ func (cm *CheckManager) AddMetricTags(metricName string, tags []string, appendTa
 				}
 			}
 
-			cm.cbmu.Lock()
-
 			if appendTags {
 				metric.Tags = append(metric.Tags, tags...)
 			} else {
 				metric.Tags = tags
 			}
 
+			cm.cbmu.Lock()
 			cm.checkBundle.Metrics[metricIdx] = metric
-			tagsUpdated = true
-
 			cm.cbmu.Unlock()
+
+			tagsUpdated = true
 		}
 	}
 

--- a/circonus-gometrics.go
+++ b/circonus-gometrics.go
@@ -115,12 +115,10 @@ func NewCirconusMetrics(cfg *Config) (*CirconusMetrics, error) {
 	}
 
 	cm.Debug = cfg.Debug
-	if cm.Debug {
-		if cfg.Log == nil {
-			cm.Log = log.New(os.Stderr, "", log.LstdFlags)
-		} else {
-			cm.Log = cfg.Log
-		}
+	cm.Log = cfg.Log
+
+	if cm.Debug && cfg.Log == nil {
+		cm.Log = log.New(os.Stderr, "", log.LstdFlags)
 	}
 	if cm.Log == nil {
 		cm.Log = log.New(ioutil.Discard, "", log.LstdFlags)

--- a/histogram.go
+++ b/histogram.go
@@ -30,11 +30,11 @@ func (m *CirconusMetrics) RecordValue(metric string, val float64) {
 // SetHistogramValue adds a value to a histogram
 func (m *CirconusMetrics) SetHistogramValue(metric string, val float64) {
 	m.NewHistogram(metric)
-
+	m.hm.Lock()
 	m.histograms[metric].rw.Lock()
-	defer m.histograms[metric].rw.Unlock()
-
 	m.histograms[metric].hist.RecordValue(val)
+	m.histograms[metric].rw.Unlock()
+	m.hm.Unlock()
 }
 
 // RemoveHistogram removes a histogram

--- a/histogram.go
+++ b/histogram.go
@@ -29,19 +29,20 @@ func (m *CirconusMetrics) RecordValue(metric string, val float64) {
 
 // SetHistogramValue adds a value to a histogram
 func (m *CirconusMetrics) SetHistogramValue(metric string, val float64) {
-	m.NewHistogram(metric)
+	hist := m.NewHistogram(metric)
+
 	m.hm.Lock()
-	m.histograms[metric].rw.Lock()
-	m.histograms[metric].hist.RecordValue(val)
-	m.histograms[metric].rw.Unlock()
+	hist.rw.Lock()
+	hist.hist.RecordValue(val)
+	hist.rw.Unlock()
 	m.hm.Unlock()
 }
 
 // RemoveHistogram removes a histogram
 func (m *CirconusMetrics) RemoveHistogram(metric string) {
 	m.hm.Lock()
-	defer m.hm.Unlock()
 	delete(m.histograms, metric)
+	m.hm.Unlock()
 }
 
 // NewHistogram returns a histogram instance.
@@ -71,7 +72,6 @@ func (h *Histogram) Name() string {
 // RecordValue records the given value to a histogram instance
 func (h *Histogram) RecordValue(v float64) {
 	h.rw.Lock()
-	defer h.rw.Unlock()
-
 	h.hist.RecordValue(v)
+	h.rw.Unlock()
 }

--- a/metrics.go
+++ b/metrics.go
@@ -1,0 +1,15 @@
+// Copyright 2016 Circonus, Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package circonusgometrics
+
+// SetMetricTags sets the tags for the named metric and flags a check update is needed
+func (m *CirconusMetrics) SetMetricTags(name string, tags []string) bool {
+	return m.check.AddMetricTags(name, tags, false)
+}
+
+// AddMetricTags appends tags to any existing tags for the named metric and flags a check update is needed
+func (m *CirconusMetrics) AddMetricTags(name string, tags []string) bool {
+	return m.check.AddMetricTags(name, tags, true)
+}

--- a/submit.go
+++ b/submit.go
@@ -107,10 +107,16 @@ func (m *CirconusMetrics) trapCall(payload []byte) (int, error) {
 			DisableCompression:  true,
 		}
 	}
-	client.RetryWaitMin = 10 * time.Millisecond
-	client.RetryWaitMax = 50 * time.Millisecond
+	client.RetryWaitMin = 1 * time.Second
+	client.RetryWaitMax = 5 * time.Second
 	client.RetryMax = 3
-	client.Logger = m.Log
+	// retryablehttp only groks log or no log
+	// but, outputs everything as [DEBUG] messages
+	if m.Debug {
+		client.Logger = m.Log
+	} else {
+		client.Logger = log.New(ioutil.Discard, "", log.LstdFlags)
+	}
 	client.CheckRetry = retryPolicy
 
 	attempts := -1

--- a/submit.go
+++ b/submit.go
@@ -21,9 +21,9 @@ import (
 )
 
 func (m *CirconusMetrics) submit(output map[string]interface{}, newMetrics map[string]*api.CheckBundleMetric) {
-	if len(newMetrics) > 0 {
-		m.check.AddNewMetrics(newMetrics)
-	}
+
+	// update check if there are any new metrics or, if metric tags have been added since last submit
+	m.check.UpdateCheck(newMetrics)
 
 	str, err := json.Marshal(output)
 	if err != nil {

--- a/util.go
+++ b/util.go
@@ -84,7 +84,9 @@ func (m *CirconusMetrics) snapshot() (c map[string]uint64, g map[string]string, 
 
 	h = make(map[string]*circonusllhist.Histogram, len(m.histograms))
 	for n, hist := range m.histograms {
+		hist.rw.Lock()
 		h[n] = hist.hist.CopyAndReset()
+		hist.rw.Unlock()
 	}
 
 	t = make(map[string]string, len(m.text)+len(m.textFuncs))

--- a/util.go
+++ b/util.go
@@ -98,5 +98,24 @@ func (m *CirconusMetrics) snapshot() (c map[string]uint64, g map[string]string, 
 		t[n] = f()
 	}
 
+	if m.resetCounters {
+		m.counters = make(map[string]uint64)
+		m.counterFuncs = make(map[string]func() uint64)
+	}
+
+	if m.resetGauges {
+		m.gauges = make(map[string]string)
+		m.gaugeFuncs = make(map[string]func() int64)
+	}
+
+	if m.resetHistograms {
+		m.histograms = make(map[string]*Histogram)
+	}
+
+	if m.resetText {
+		m.text = make(map[string]string)
+		m.textFuncs = make(map[string]func() string)
+	}
+
 	return
 }


### PR DESCRIPTION
* add: per metric tagging add(append) and set(replace)
* add: reset metrics after flush, default true, expose configuration options
* add: multiple tags for searching (check/broker)
* chg: check tags setting is now a string
* fix: tighter histogram and check bundle locking
* upd: increase check management retries to 5, expand retry min/max to get past rate limits
* fix: silence subpkg debug messages when debugging is set off
