### PR TITLE
Broker updates, default target to hostname only.

### DIFF
--- a/api/broker.go
+++ b/api/broker.go
@@ -12,14 +12,16 @@ import (
 
 // BrokerDetail instance attributes
 type BrokerDetail struct {
-	CN      string   `json:"cn"`
-	IP      string   `json:"ipaddress"`
-	MinVer  int      `json:"minimum_version_required"`
-	Modules []string `json:"modules"`
-	Port    int      `json:"port"`
-	Skew    string   `json:"skew"`
-	Status  string   `json:"status"`
-	Version int      `json:"version"`
+	CN           string   `json:"cn"`
+	ExternalHost string   `json:"external_host"`
+	ExternalPort int      `json:"external_port"`
+	IP           string   `json:"ipaddress"`
+	MinVer       int      `json:"minimum_version_required"`
+	Modules      []string `json:"modules"`
+	Port         int      `json:"port"`
+	Skew         string   `json:"skew"`
+	Status       string   `json:"status"`
+	Version      int      `json:"version"`
 }
 
 // Broker definition

--- a/checkmgr/check.go
+++ b/checkmgr/check.go
@@ -127,8 +127,8 @@ func (cm *CheckManager) initializeTrapURL() error {
 		}
 	} else {
 		searchCriteria := fmt.Sprintf(
-			"(active:1)(host:\"%s\")(type:\"%s\")(tags:%s)",
-			cm.checkInstanceID, cm.checkType, strings.Join(cm.checkSearchTag, ","))
+			"(active:1)(host:\"%s\")(type:\"%s\")(tags:%s)(notes:%s)",
+			cm.checkTarget, cm.checkType, strings.Join(cm.checkSearchTag, ","), fmt.Sprintf("cgm_instanceid=%s", cm.checkInstanceID))
 		checkBundle, err = cm.checkBundleSearch(searchCriteria)
 		if err != nil {
 			return err
@@ -243,11 +243,11 @@ func (cm *CheckManager) createNewCheck() (*api.CheckBundle, *api.Broker, error) 
 		DisplayName: string(cm.checkDisplayName),
 		Metrics:     []api.CheckBundleMetric{},
 		MetricLimit: 0,
-		Notes:       "",
+		Notes:       fmt.Sprintf("cgm_instanceid=%s", cm.checkInstanceID),
 		Period:      60,
 		Status:      statusActive,
 		Tags:        append(cm.checkSearchTag, cm.checkTags...),
-		Target:      string(cm.checkInstanceID),
+		Target:      cm.checkTarget,
 		Timeout:     10,
 		Type:        string(cm.checkType),
 	}

--- a/checkmgr/checkmgr.go
+++ b/checkmgr/checkmgr.go
@@ -138,6 +138,7 @@ type CheckManager struct {
 	checkType             CheckTypeType
 	checkID               api.IDType
 	checkInstanceID       CheckInstanceIDType
+	checkTarget           string
 	checkSearchTag        api.TagType
 	checkSecret           CheckSecretType
 	checkTags             api.TagType
@@ -258,6 +259,7 @@ func NewCheckManager(cfg *Config) (*CheckManager, error) {
 	if cm.checkInstanceID == "" {
 		cm.checkInstanceID = CheckInstanceIDType(fmt.Sprintf("%s:%s", hn, an))
 	}
+	cm.checkTarget = hn
 
 	if cfg.Check.SearchTag == "" {
 		cm.checkSearchTag = []string{fmt.Sprintf("service:%s", an)}
@@ -270,7 +272,7 @@ func NewCheckManager(cfg *Config) (*CheckManager, error) {
 	}
 
 	if cm.checkDisplayName == "" {
-		cm.checkDisplayName = CheckDisplayNameType(fmt.Sprintf("%s /cgm", string(cm.checkInstanceID)))
+		cm.checkDisplayName = CheckDisplayNameType(fmt.Sprintf("%s", string(cm.checkInstanceID)))
 	}
 
 	dur := cfg.Check.MaxURLAge


### PR DESCRIPTION
Use os.Hostname() instead of instanceID for check bundle target.
Add cgm_instanceid=instanceID to notes for existing check searching.
Update broker to preference external_host and external_port if set.