### PR TITLE
Retrieve check bundle on updates

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -83,7 +83,7 @@ func TestApiCall(t *testing.T) {
 		t.Errorf("Expected error, got '%+v'", resp)
 	}
 
-	expected := fmt.Sprintf("[ERROR] fetching: GET %s/retrytest giving up after 5 attempts - last HTTP error: 500 blah blah blah\n", server.URL)
+	expected := "- last HTTP error: 500 blah blah blah\n"
 	if err.Error() != expected {
 		t.Errorf("Expected\n'%s'\ngot\n'%s'\n", expected, err)
 	}


### PR DESCRIPTION
get an up-to-date copy of the check bundle before applying any updates (new metrics, tags, etc.) to catch any changes to the check bundle performed elsewhere (another app, UI, etc.)