### PR TITLE
Fixes to make identifying an existing check more robust

### DIFF
--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -1,0 +1,98 @@
+## Circonus gometrics options
+
+### Example defaults
+```go
+package main
+
+import (
+    "fmt"
+    "io/ioutil"
+    "log"
+    "os"
+    "path"
+
+    cgm "github.com/circonus-labs/circonus-gometrics"
+)
+
+func main() {
+    cfg := &cgm.Config{}
+
+    // Defaults
+
+    // General
+    cfg.Debug = false
+    cfg.Log = log.New(ioutil.Discard, "", log.LstdFlags)
+    cfg.Interval = "10s"
+    cfg.ResetCounters = "true"
+    cfg.ResetGauges = "true"
+    cfg.ResetHistograms = "true"
+    cfg.ResetText = "true"
+
+    // API
+    cfg.CheckManager.API.TokenKey = ""
+    cfg.CheckManager.API.TokenApp = ""
+    cfg.CheckManager.API.TokenURL = "https://api.circonus.com/v2"
+
+    // Check
+    _, an := path.Split(os.Args[0])
+    hn, _ := os.Hostname()
+    cfg.CheckManager.Check.ID = ""
+    cfg.CheckManager.Check.SubmissionURL = ""
+    cfg.CheckManager.Check.InstanceID = fmt.Sprintf("%s:%s", hn, an)
+    cfg.CheckManager.Check.TargetHost = cfg.CheckManager.Check.InstanceID
+    cfg.CheckManager.Check.DisplayName = cfg.CheckManager.Check.InstanceID
+    cfg.CheckManager.Check.SearchTag = fmt.Sprintf("service:%s", an)
+    cfg.CheckManager.Check.Tags = ""
+    cfg.CheckManager.Check.Secret = "" // randomly generated sha256 hash
+    cfg.CheckManager.Check.MaxURLAge = "5m"
+    cfg.CheckManager.Check.ForceMetricActivation = "false"
+
+    // Broker
+    cfg.CheckManager.Broker.ID = ""
+    cfg.CheckManager.Broker.SelectTag = ""
+    cfg.CheckManager.Broker.MaxResponseTime = "500ms"
+
+    // create a new cgm instance and start sending metrics...
+    // see the complete example in the main README.    
+}
+```
+
+## Options
+| Option | Default | Description |
+| ------ | ------- | ----------- |
+| General ||
+| `cfg.Log` | none | log.Logger instance to send logging messages. Default is to discard messages. If Debug is turned on and no instance is specified, messages will go to stderr. |
+| `cfg.Debug` | false | Turn on debugging messages. |
+| `cfg.Interval` | "10s" | Interval at which metrics are flushed and send to Circonus. |
+| `cfg.ResetCounters` | "true" | Reset counter metrics after each submission. |
+| `cfg.ResetGauges` | "true" | Reset gauge metrics after each submission. |
+| `cfg.ResetHistograms` | "true" | Reset histogram metrics after each submission. |
+| `cfg.ResetText` | "true" | Reset text metrics after each submission. |
+|API||
+| `cfg.CheckManager.API.TokenKey` | "" | [Circonus API Token key](https://login.circonus.com/user/tokens) |
+| `cfg.CheckManager.API.TokenApp` | "" | App associated with API token |
+| `cfg.CheckManager.API.URL` | "https://api.circonus.com/v2" | Circonus API URL |
+|Check||
+| `cfg.CheckManager.Check.ID` | "" | Check ID of previously created check. (*Note: **check id** not **check bundle id**.*) |
+| `cfg.CheckManager.Check.SubmissionURL` | "" | Submission URL of previously created check. |
+| `cfg.CheckManager.Check.InstanceID` | hostname:program name | An identifier for the 'group of metrics emitted by this process or service'. |
+| `cfg.CheckManager.Check.TargetHost` | InstanceID | Explicit setting of `check.target`. |
+| `cfg.CheckManager.Check.DisplayName` | InstanceID | Custom `check.display_name`. Shows in UI check list. |
+| `cfg.CheckManager.Check.SearchTag` | service:program name | Specific tag used to search for an existing check when neither SubmissionURL nor ID are provided. |
+| `cfg.CheckManager.Check.Tags` | "" | List (comma separated) of tags to add to check when it is being created. The SearchTag will be added to the list. |
+| `cfg.CheckManager.Check.Secret` | random generated | A secret to use for when creating an httptrap check. |
+| `cfg.CheckManager.Check.MaxURLAge` | "5m" | Maximum amount of time to retry a [failing] submission URL before refreshing it. |
+| `cfg.CheckManager.Check.ForceMetricActivation` | "false" | If a metric has been disabled via the UI the default behavior is to *not* re-activate the metric; this setting overrides the behavior and will re-activate the metric when it is encountered. |
+|Broker||
+| `cfg.CheckManager.Broker.ID` | "" | ID of a specific broker to use when creating a check. Default is to use a random enterprise broker or the public Circonus default broker. |
+| `cfg.CheckManager.Broker.SelectTag` | "" | Used to select a broker with the same tag(s). If more than one broker has the tag(s), one will be selected randomly from the resulting list. (e.g. could be used to select one from a list of brokers serving a specific colo/region. "dc:sfo", "loc:nyc,dc:nyc01", "zone:us-west") |
+| `cfg.CheckManager.Broker.MaxResponseTime` | "500ms" | Maximum amount time to wait for a broker connection test to be considered valid. (if latency is > the broker will be considered invalid and not available for selection.) |
+
+## Notes:
+
+* All options are *strings* with the following exceptions:
+   * `cfg.Log` - an instance of [`log.Logger`](https://golang.org/pkg/log/#Logger) or something else (e.g. [logrus](https://github.com/Sirupsen/logrus)) which can be used to satisfy the interface requirements.
+   * `cfg.Debug` - a boolean true|false.
+* At a minimum, one of either `API.TokenKey` or `Check.SubmissionURL` is **required** for cgm to function.
+* Check management can be disabled by providing a `Check.SubmissionURL` without an `API.TokenKey`. Note: the supplied URL needs to be http or the broker needs to be running with a cert which can be verified. Otherwise, the `API.TokenKey` will be required to retrieve the correct CA certificate to validate the broker's cert for the SSL connection.
+* A note on `Check.InstanceID`, the instance id is used to consistently identify a check. The display name can be changed in the UI. The hostname may be ephemeral. For metric continuity, the instance id is used to locate existing checks. Since the check.target is never actually used by an httptrap check it is more decorative than functional, a valid FQDN is not required for an httptrap check.target. But, using instance id as the target can pollute the Host list in the UI.

--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -30,7 +30,7 @@ func main() {
 
     // API
     cfg.CheckManager.API.TokenKey = ""
-    cfg.CheckManager.API.TokenApp = ""
+    cfg.CheckManager.API.TokenApp = "circonus-gometrics"
     cfg.CheckManager.API.TokenURL = "https://api.circonus.com/v2"
 
     // Check
@@ -63,14 +63,14 @@ func main() {
 | General ||
 | `cfg.Log` | none | log.Logger instance to send logging messages. Default is to discard messages. If Debug is turned on and no instance is specified, messages will go to stderr. |
 | `cfg.Debug` | false | Turn on debugging messages. |
-| `cfg.Interval` | "10s" | Interval at which metrics are flushed and send to Circonus. |
+| `cfg.Interval` | "10s" | Interval at which metrics are flushed and sent to Circonus. |
 | `cfg.ResetCounters` | "true" | Reset counter metrics after each submission. |
 | `cfg.ResetGauges` | "true" | Reset gauge metrics after each submission. |
 | `cfg.ResetHistograms` | "true" | Reset histogram metrics after each submission. |
 | `cfg.ResetText` | "true" | Reset text metrics after each submission. |
 |API||
 | `cfg.CheckManager.API.TokenKey` | "" | [Circonus API Token key](https://login.circonus.com/user/tokens) |
-| `cfg.CheckManager.API.TokenApp` | "" | App associated with API token |
+| `cfg.CheckManager.API.TokenApp` | "circonus-gometrics" | App associated with API token |
 | `cfg.CheckManager.API.URL` | "https://api.circonus.com/v2" | Circonus API URL |
 |Check||
 | `cfg.CheckManager.Check.ID` | "" | Check ID of previously created check. (*Note: **check id** not **check bundle id**.*) |
@@ -95,4 +95,4 @@ func main() {
    * `cfg.Debug` - a boolean true|false.
 * At a minimum, one of either `API.TokenKey` or `Check.SubmissionURL` is **required** for cgm to function.
 * Check management can be disabled by providing a `Check.SubmissionURL` without an `API.TokenKey`. Note: the supplied URL needs to be http or the broker needs to be running with a cert which can be verified. Otherwise, the `API.TokenKey` will be required to retrieve the correct CA certificate to validate the broker's cert for the SSL connection.
-* A note on `Check.InstanceID`, the instance id is used to consistently identify a check. The display name can be changed in the UI. The hostname may be ephemeral. For metric continuity, the instance id is used to locate existing checks. Since the check.target is never actually used by an httptrap check it is more decorative than functional, a valid FQDN is not required for an httptrap check.target. But, using instance id as the target can pollute the Host list in the UI.
+* A note on `Check.InstanceID`, the instance id is used to consistently identify a check. The display name can be changed in the UI. The hostname may be ephemeral. For metric continuity, the instance id is used to locate existing checks. Since the check.target is never actually used by an httptrap check it is more decorative than functional, a valid FQDN is not required for an httptrap check.target. But, using instance id as the target can pollute the Host list in the UI with host:application specific entries.

--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -64,10 +64,10 @@ func main() {
 | `cfg.Log` | none | log.Logger instance to send logging messages. Default is to discard messages. If Debug is turned on and no instance is specified, messages will go to stderr. |
 | `cfg.Debug` | false | Turn on debugging messages. |
 | `cfg.Interval` | "10s" | Interval at which metrics are flushed and sent to Circonus. |
-| `cfg.ResetCounters` | "true" | Reset counter metrics after each submission. |
-| `cfg.ResetGauges` | "true" | Reset gauge metrics after each submission. |
-| `cfg.ResetHistograms` | "true" | Reset histogram metrics after each submission. |
-| `cfg.ResetText` | "true" | Reset text metrics after each submission. |
+| `cfg.ResetCounters` | "true" | Reset counter metrics after each submission. Change to "false" to retain (and continue submitting) the last value.|
+| `cfg.ResetGauges` | "true" | Reset gauge metrics after each submission. Change to "false" to retain (and continue submitting) the last value.|
+| `cfg.ResetHistograms` | "true" | Reset histogram metrics after each submission. Change to "false" to retain (and continue submitting) the last value.|
+| `cfg.ResetText` | "true" | Reset text metrics after each submission. Change to "false" to retain (and continue submitting) the last value.|
 |API||
 | `cfg.CheckManager.API.TokenKey` | "" | [Circonus API Token key](https://login.circonus.com/user/tokens) |
 | `cfg.CheckManager.API.TokenApp` | "circonus-gometrics" | App associated with API token |
@@ -96,3 +96,12 @@ func main() {
 * At a minimum, one of either `API.TokenKey` or `Check.SubmissionURL` is **required** for cgm to function.
 * Check management can be disabled by providing a `Check.SubmissionURL` without an `API.TokenKey`. Note: the supplied URL needs to be http or the broker needs to be running with a cert which can be verified. Otherwise, the `API.TokenKey` will be required to retrieve the correct CA certificate to validate the broker's cert for the SSL connection.
 * A note on `Check.InstanceID`, the instance id is used to consistently identify a check. The display name can be changed in the UI. The hostname may be ephemeral. For metric continuity, the instance id is used to locate existing checks. Since the check.target is never actually used by an httptrap check it is more decorative than functional, a valid FQDN is not required for an httptrap check.target. But, using instance id as the target can pollute the Host list in the UI with host:application specific entries.
+* Check identification precedence
+   1. Check SubmissionURL
+   2. Check ID
+   3. Search
+      1. Search for an active httptrap check for TargetHost which has the SearchTag
+      2. Search for an active httptrap check which has the SearchTag and the InstanceID in the notes field
+      3. Create a new check
+* Broker selection
+   1. If Broker.ID or Broker.SelectTag are not specified, a broker will be selected randomly from the list of brokers available to the API token. Enterprise brokers take precedence. A viable broker is "active", has the "httptrap" module enabled, and responds within Broker.MaxResponseTime.

--- a/README.md
+++ b/README.md
@@ -85,14 +85,25 @@ func main() {
 	// httptrap check by using the circonus api to search for a check matching the following criteria:
 	//      an active check,
 	//      of type httptrap,
-	//      where the target/host is equal to InstanceId - see below
+	//      where the target/host is equal to TargetHost - see below
 	//      and the check has a tag equal to SearchTag - see below
+    //      and the check has InstanceID in the notes field
+
 	// Instance ID - an identifier for the 'group of metrics emitted by this process or service'
-	//               this is used as the value for check.target (aka host)
 	// default: 'hostname':'program name'
 	// note: for a persistent instance that is ephemeral or transient where metric continuity is
 	//       desired set this explicitly so that the current hostname will not be used.
 	// cmc.CheckManager.Check.InstanceID = ""
+
+    // custom display name for check, default: InstanceID
+	// cmc.CheckManager.Check.DisplayName = ""
+
+    // explicitly setting check.target, default: InstanceID
+    // cmc.CheckManager.Check.TargetHost = ""
+    // e.g.
+    //  if hn, err := os.Hostname(); err == nil {
+    //      cmc.CheckManager.Check.TargetHost = hn
+    //  }
 
 	// Search tag - specific tag(s) used in conjunction with isntanceId to search for an
     // existing check. comma separated string of tags (spaces will be removed, no commas
@@ -115,9 +126,6 @@ func main() {
 	// url will be refreshed (e.g. if the broker is changed
 	// in the UI) default 5 minutes
 	// cmc.CheckManager.Check.MaxURLAge = "5m"
-
-	// custom display name for check, default: "InstanceId /cgm"
-	// cmc.CheckManager.Check.DisplayName = ""
 
     // force metric activation - if a metric has been disabled via the UI
 	// the default behavior is to *not* re-activate the metric; this setting

--- a/README.md
+++ b/README.md
@@ -111,129 +111,40 @@ func main() {
 
 	cmc := &cgm.Config{}
 
-	// Interval at which metrics are submitted to Circonus, default: 10 seconds
-	// cmc.Interval = "10s" // 10 seconds
+    // General
 
-	// Enable debug messages, default: false
-	cmc.Debug = true
-
-	// Send debug messages to specific log.Logger instance
-	// default: if debug stderr, else, discard
-	cmc.Log = logger
-
-    // Reset counter metrics after each submission, default: "true"
-    // Change to "false" to retain (and continue submitting) the last value.
-    // cmc.ResetCounters = "true"
-
-    // Reset gauge metrics after each submission, default: "true"
-    // Change to "false" to retain (and continue submitting) the last value.
-    // cmc.ResetGauges = "true"
-
-    // Reset histogram metrics after each submission, default: "true"
-    // Change to "false" to retain (and continue submitting) the last value.
-    // cmc.ResetHistograms = "true"
-
-    // Reset text metrics after each submission, default: "true"
-    // Change to "false" to retain (and continue submitting) the last value.
-    // cmc.ResetText = "true"
+	cmc.Interval = "10s"
+    cmc.Log = logger
+	cmc.Debug = false
+    cmc.ResetCounters = "true"
+    cmc.ResetGauges = "true"
+    cmc.ResetHistograms = "true"
+    cmc.ResetText = "true"
 
 	// Circonus API configuration options
-	//
-	// Token, no default (blank disables check manager)
 	cmc.CheckManager.API.TokenKey = os.Getenv("CIRCONUS_API_TOKEN")
-	// App name, default: circonus-gometrics
 	cmc.CheckManager.API.TokenApp = os.Getenv("CIRCONUS_API_APP")
-	// URL, default: https://api.circonus.com/v2
 	cmc.CheckManager.API.URL = os.Getenv("CIRCONUS_API_URL")
 
 	// Check configuration options
-	//
-	// precedence 1 - explicit submission_url
-	// precedence 2 - specific check id (note: not a check bundle id)
-	// precedence 3 - search using instanceId and searchTag
-	// otherwise: if an applicable check is NOT specified or found, an
-	//            attempt will be made to automatically create one
-	//
-	// Submission URL for an existing [httptrap] check
 	cmc.CheckManager.Check.SubmissionURL = os.Getenv("CIRCONUS_SUBMISION_URL")
-
-	// ID of an existing [httptrap] check (note: check id not check bundle id)
 	cmc.CheckManager.Check.ID = os.Getenv("CIRCONUS_CHECK_ID")
-
-	// if neither a submission url nor check id are provided, an attempt will be made to find an existing
-	// httptrap check by using the circonus api to search for a check matching the following criteria:
-	//      an active check,
-	//      of type httptrap,
-	//      where the target/host is equal to TargetHost - see below
-	//      and the check has a tag equal to SearchTag - see below
-    //      and the check has InstanceID in the notes field
-
-	// Instance ID - an identifier for the 'group of metrics emitted by this process or service'
-	// default: 'hostname':'program name'
-	// note: for a persistent instance that is ephemeral or transient where metric continuity is
-	//       desired set this explicitly so that the current hostname will not be used.
-	// cmc.CheckManager.Check.InstanceID = ""
-
-    // custom display name for check, default: InstanceID
-	// cmc.CheckManager.Check.DisplayName = ""
-
-    // explicitly setting check.target, default: InstanceID
-    // cmc.CheckManager.Check.TargetHost = ""
-    // e.g.
+	cmc.CheckManager.Check.InstanceID = ""
+	cmc.CheckManager.Check.DisplayName = ""
+    cmc.CheckManager.Check.TargetHost = ""
     //  if hn, err := os.Hostname(); err == nil {
     //      cmc.CheckManager.Check.TargetHost = hn
     //  }
-
-	// Search tag - specific tag(s) used in conjunction with isntanceId to search for an
-    // existing check. comma separated string of tags (spaces will be removed, no commas
-    // in tag elements).
-	// default: service:application name (e.g. service:consul service:nomad etc.)
-	// cmc.CheckManager.Check.SearchTag = ""
-
-	// Check secret, default: generated when a check needs to be created
-	// cmc.CheckManager.Check.Secret = ""
-
-	// Additional tag(s) to add when *creating* a check. comma separated string
-    // of tags (spaces will be removed, no commas in tag elements).
-    // (e.g. group:abc or service_role:agent,group:xyz).
-    // default: none
-	// cmc.CheckManager.Check.Tags = ""
-
-	// max amount of time to to hold on to a submission url
-	// when a given submission fails (due to retries) if the
-	// time the url was last updated is > than this, the trap
-	// url will be refreshed (e.g. if the broker is changed
-	// in the UI) default 5 minutes
-	// cmc.CheckManager.Check.MaxURLAge = "5m"
-
-    // force metric activation - if a metric has been disabled via the UI
-	// the default behavior is to *not* re-activate the metric; this setting
-	// overrides the behavior and will re-activate the metric when it is
-	// encountered. "(true|false)", default "false"
-	// cmc.CheckManager.Check.ForceMetricActivation = "false"
+	cmc.CheckManager.Check.SearchTag = ""
+	cmc.CheckManager.Check.Secret = ""
+	cmc.CheckManager.Check.Tags = ""
+	cmc.CheckManager.Check.MaxURLAge = "5m"
+	cmc.CheckManager.Check.ForceMetricActivation = "false"
 
 	// Broker configuration options
-	//
-	// Broker ID of specific broker to use, default: random enterprise broker or
-	// Circonus default if no enterprise brokers are available.
-	// default: only used if set
-	// cmc.CheckManager.Broker.ID = ""
-
-	// used to select a broker with the same tag(s) (e.g. can be used to dictate that a broker
-	// serving a specific location should be used. "dc:sfo", "loc:nyc,dc:nyc01", "zone:us-west")
-	// if more than one broker has the tag(s), one will be selected randomly from the resulting
-    // list. comma separated string of tags (spaces will be removed, no commas in tag elements).
-	// default: none
-	// cmc.CheckManager.Broker.SelectTag = ""
-
-	// longest time to wait for a broker connection (if latency is > the broker will
-	// be considered invalid and not available for selection.), default: 500 milliseconds
-	// cmc.CheckManager.Broker.MaxResponseTime = "500ms"
-
-	// note: if broker Id or SelectTag are not specified, a broker will be selected randomly
-	// from the list of brokers available to the api token. enterprise brokers take precedence
-	// viable brokers are "active", have the "httptrap" module enabled, are reachable and respond
-	// within MaxResponseTime.
+	cmc.CheckManager.Broker.ID = ""
+	cmc.CheckManager.Broker.SelectTag = ""
+	cmc.CheckManager.Broker.MaxResponseTime = "500ms"
 
 	logger.Println("Creating new cgm instance")
 

--- a/api/check_bundle.go
+++ b/api/check_bundle.go
@@ -91,7 +91,7 @@ func (a *API) FetchCheckBundleByCID(cid CIDType) (*CheckBundle, error) {
 }
 
 // CheckBundleSearch returns list of check bundles matching a search query
-//    - a search query not a filter (see: https://login.circonus.com/resources/api#searching)
+//    - a search query (see: https://login.circonus.com/resources/api#searching)
 func (a *API) CheckBundleSearch(searchCriteria SearchQueryType) ([]CheckBundle, error) {
 	reqURL := url.URL{
 		Path: baseCheckBundlePath,
@@ -117,7 +117,8 @@ func (a *API) CheckBundleSearch(searchCriteria SearchQueryType) ([]CheckBundle, 
 }
 
 // CheckBundleFilterSearch returns list of check bundles matching a search query and filter
-//    - a search query not a filter (see: https://login.circonus.com/resources/api#searching)
+//    - a search query (see: https://login.circonus.com/resources/api#searching)
+//    - a filter (see: https://login.circonus.com/resources/api#filtering)
 func (a *API) CheckBundleFilterSearch(searchCriteria SearchQueryType, filterCriteria map[string]string) ([]CheckBundle, error) {
 	reqURL := url.URL{
 		Path: baseCheckBundlePath,

--- a/api/check_bundle.go
+++ b/api/check_bundle.go
@@ -116,6 +116,35 @@ func (a *API) CheckBundleSearch(searchCriteria SearchQueryType) ([]CheckBundle, 
 	return results, nil
 }
 
+// CheckBundleFilterSearch returns list of check bundles matching a search query and filter
+//    - a search query not a filter (see: https://login.circonus.com/resources/api#searching)
+func (a *API) CheckBundleFilterSearch(searchCriteria SearchQueryType, filterCriteria map[string]string) ([]CheckBundle, error) {
+	reqURL := url.URL{
+		Path: baseCheckBundlePath,
+	}
+
+	if searchCriteria != "" {
+		q := url.Values{}
+		q.Set("search", string(searchCriteria))
+		for field, val := range filterCriteria {
+			q.Set(field, val)
+		}
+		reqURL.RawQuery = q.Encode()
+	}
+
+	resp, err := a.Get(reqURL.String())
+	if err != nil {
+		return nil, fmt.Errorf("[ERROR] API call error %+v", err)
+	}
+
+	var results []CheckBundle
+	if err := json.Unmarshal(resp, &results); err != nil {
+		return nil, err
+	}
+
+	return results, nil
+}
+
 // CreateCheckBundle create a new check bundle (check)
 func (a *API) CreateCheckBundle(config *CheckBundle) (*CheckBundle, error) {
 	reqURL := url.URL{

--- a/api/check_bundle_test.go
+++ b/api/check_bundle_test.go
@@ -228,6 +228,20 @@ func TestCheckBundleSearch(t *testing.T) {
 			t.Fatalf("Expected %s, got %s", expectedType, actualType.String())
 		}
 	}
+
+	t.Log("Testing with search and filter criteria")
+	{
+		bundles, err := apih.CheckBundleFilterSearch("test", map[string]string{"f_notes": "foo"})
+		if err != nil {
+			t.Fatalf("Expected no error, got '%v'", err)
+		}
+
+		actualType := reflect.TypeOf(bundles)
+		expectedType := "[]api.CheckBundle"
+		if actualType.String() != expectedType {
+			t.Fatalf("Expected %s, got %s", expectedType, actualType.String())
+		}
+	}
 }
 
 func TestCreateCheckBundle(t *testing.T) {

--- a/checkmgr/check.go
+++ b/checkmgr/check.go
@@ -146,12 +146,25 @@ func (cm *CheckManager) initializeTrapURL() error {
 			return fmt.Errorf("[ERROR] Check ID %v is not active", check.CID)
 		}
 	} else {
-		searchCriteria := fmt.Sprintf(
-			"(active:1)(type:\"%s\")(tags:%s)", cm.checkType, strings.Join(cm.checkSearchTag, ","))
-		filterCriteria := map[string]string{"f_notes": cm.getNotes()}
-		checkBundle, err = cm.checkBundleSearch(searchCriteria, filterCriteria)
-		if err != nil {
-			return err
+		if checkBundle == nil {
+			// old search (instanceid as check.target)
+			searchCriteria := fmt.Sprintf(
+				"(active:1)(type:\"%s\")(host:\"%s\")(tags:%s)", cm.checkType, cm.checkTarget, strings.Join(cm.checkSearchTag, ","))
+			checkBundle, err = cm.checkBundleSearch(searchCriteria, map[string]string{})
+			if err != nil {
+				return err
+			}
+		}
+
+		if checkBundle == nil {
+			// new search (check.target != instanceid, instanceid encoded in notes field)
+			searchCriteria := fmt.Sprintf(
+				"(active:1)(type:\"%s\")(tags:%s)", cm.checkType, strings.Join(cm.checkSearchTag, ","))
+			filterCriteria := map[string]string{"f_notes": cm.getNotes()}
+			checkBundle, err = cm.checkBundleSearch(searchCriteria, filterCriteria)
+			if err != nil {
+				return err
+			}
 		}
 
 		if checkBundle == nil {

--- a/checkmgr/check.go
+++ b/checkmgr/check.go
@@ -147,10 +147,7 @@ func (cm *CheckManager) initializeTrapURL() error {
 		}
 	} else {
 		searchCriteria := fmt.Sprintf(
-			"(active:1)(host:\"%s\")(type:\"%s\")(tags:%s)",
-			cm.checkTarget,
-			cm.checkType,
-			strings.Join(cm.checkSearchTag, ","))
+			"(active:1)(type:\"%s\")(tags:%s)", cm.checkType, strings.Join(cm.checkSearchTag, ","))
 		filterCriteria := map[string]string{"f_notes": cm.getNotes()}
 		checkBundle, err = cm.checkBundleSearch(searchCriteria, filterCriteria)
 		if err != nil {

--- a/checkmgr/check_test.go
+++ b/checkmgr/check_test.go
@@ -114,7 +114,7 @@ func testCheckServer() *httptest.Server {
 		case "/check_bundle":
 			switch r.Method {
 			case "GET": // search
-				if strings.HasPrefix(r.URL.String(), "/check_bundle?search=") {
+				if strings.HasPrefix(r.URL.String(), "/check_bundle?") && strings.Contains(r.URL.String(), "search=") {
 					r := []api.CheckBundle{testCheckBundle}
 					ret, err := json.Marshal(r)
 					if err != nil {

--- a/checkmgr/check_test.go
+++ b/checkmgr/check_test.go
@@ -114,7 +114,17 @@ func testCheckServer() *httptest.Server {
 		case "/check_bundle":
 			switch r.Method {
 			case "GET": // search
-				if strings.HasPrefix(r.URL.String(), "/check_bundle?") && strings.Contains(r.URL.String(), "search=") {
+				//fmt.Println(r.URL.String())
+				if strings.HasPrefix(r.URL.String(), "/check_bundle?f_notes=") && strings.Contains(r.URL.String(), "found_notes") {
+					r := []api.CheckBundle{testCheckBundle}
+					ret, err := json.Marshal(r)
+					if err != nil {
+						panic(err)
+					}
+					w.WriteHeader(200)
+					w.Header().Set("Content-Type", "application/json")
+					fmt.Fprintln(w, string(ret))
+				} else if strings.HasPrefix(r.URL.String(), "/check_bundle?search=") && strings.Contains(r.URL.String(), "found_target") {
 					r := []api.CheckBundle{testCheckBundle}
 					ret, err := json.Marshal(r)
 					if err != nil {
@@ -421,10 +431,25 @@ func TestInitializeTrapURL(t *testing.T) {
 	cm.checkID = 0
 	cm.checkTarget = "test_t"
 	cm.checkInstanceID = "test_id"
-	cm.checkSearchTag = api.TagType([]string{"cat:tag"})
+	cm.checkSearchTag = api.TagType([]string{"s:found_target"})
 	cm.checkDisplayName = "test_dn"
 
-	t.Log("cm enabled, search [found]")
+	t.Log("cm enabled, search [found by target]")
+	{
+		if err := cm.initializeTrapURL(); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+	}
+
+	cm.trapURL = ""
+	cm.checkSubmissionURL = ""
+	cm.checkID = 0
+	cm.checkTarget = "test_t"
+	cm.checkInstanceID = "test_id"
+	cm.checkSearchTag = api.TagType([]string{"s:found_notes"})
+	cm.checkDisplayName = "test_dn"
+
+	t.Log("cm enabled, search [found by notes]")
 	{
 		if err := cm.initializeTrapURL(); err != nil {
 			t.Fatalf("Expected no error, got %v", err)

--- a/checkmgr/checkmgr.go
+++ b/checkmgr/checkmgr.go
@@ -59,12 +59,15 @@ type CheckConfig struct {
 	// used to search for a check to use
 	// used as check.target when creating a check
 	InstanceID string
+	// explicitly set check.target (default: instance id)
+	TargetHost string
+	// a custom display name for the check (as viewed in UI Checks)
+	// default: instance id
+	DisplayName string
 	// unique check searching tag (or tags)
 	// used to search for a check to use (combined with instanceid)
 	// used as a regular tag when creating a check
 	SearchTag string
-	// a custom display name for the check (as viewed in UI Checks)
-	DisplayName string
 	// httptrap check secret (for creating a check)
 	Secret string
 	// additional tags to add to a check (when creating a check)
@@ -115,6 +118,9 @@ type CheckTypeType string
 // CheckInstanceIDType check instance id
 type CheckInstanceIDType string
 
+// CheckTargetType check target/host
+type CheckTargetType string
+
 // CheckSecretType check secret
 type CheckSecretType string
 
@@ -138,7 +144,7 @@ type CheckManager struct {
 	checkType             CheckTypeType
 	checkID               api.IDType
 	checkInstanceID       CheckInstanceIDType
-	checkTarget           string
+	checkTarget           CheckTargetType
 	checkSearchTag        api.TagType
 	checkSecret           CheckSecretType
 	checkTags             api.TagType
@@ -238,6 +244,7 @@ func NewCheckManager(cfg *Config) (*CheckManager, error) {
 	cm.checkID = api.IDType(id)
 
 	cm.checkInstanceID = CheckInstanceIDType(cfg.Check.InstanceID)
+	cm.checkTarget = CheckTargetType(cfg.Check.TargetHost)
 	cm.checkDisplayName = CheckDisplayNameType(cfg.Check.DisplayName)
 	cm.checkSecret = CheckSecretType(cfg.Check.Secret)
 
@@ -259,7 +266,12 @@ func NewCheckManager(cfg *Config) (*CheckManager, error) {
 	if cm.checkInstanceID == "" {
 		cm.checkInstanceID = CheckInstanceIDType(fmt.Sprintf("%s:%s", hn, an))
 	}
-	cm.checkTarget = hn
+	if cm.checkDisplayName == "" {
+		cm.checkDisplayName = CheckDisplayNameType(cm.checkInstanceID)
+	}
+	if cm.checkTarget == "" {
+		cm.checkTarget = CheckTargetType(cm.checkInstanceID)
+	}
 
 	if cfg.Check.SearchTag == "" {
 		cm.checkSearchTag = []string{fmt.Sprintf("service:%s", an)}
@@ -269,10 +281,6 @@ func NewCheckManager(cfg *Config) (*CheckManager, error) {
 
 	if cfg.Check.Tags != "" {
 		cm.checkTags = strings.Split(strings.Replace(cfg.Check.Tags, " ", "", -1), ",")
-	}
-
-	if cm.checkDisplayName == "" {
-		cm.checkDisplayName = CheckDisplayNameType(fmt.Sprintf("%s", string(cm.checkInstanceID)))
 	}
 
 	dur := cfg.Check.MaxURLAge


### PR DESCRIPTION
* add OPTIONS.md, migrating documentation on available configuration options to a dedicated file
* expose explicit setting of check.target (cfg.CheckManager.Check.TargetHost)
* add additional filtered search for check bundle (using notes field)
* searching:
   1. try searching for active, type httptrap, host TargetHost, tags has SearchTag
   2. if that fails, search for active, type httptrap, tags has SearchTag and filter by notes contains InstanceID
   3. if both fail, create a new check
