### PR TITLE
Fix: redundant metric tag submissions

### DIFF
--- a/checkmgr/metrics.go
+++ b/checkmgr/metrics.go
@@ -54,7 +54,7 @@ func (cm *CheckManager) AddMetricTags(metricName string, tags []string, appendTa
 		}
 	}
 
-	action := "no new"
+	action := ""
 	if appendTags {
 		numNewTags := countNewTags(currentTags, tags)
 		if numNewTags > 0 {
@@ -63,15 +63,14 @@ func (cm *CheckManager) AddMetricTags(metricName string, tags []string, appendTa
 			tagsUpdated = true
 		}
 	} else {
-		action = "Set"
-		if len(tags) == 0 {
-			if len(currentTags) > 0 {
-				currentTags = []string{}
-				tagsUpdated = true
-			}
+		if len(tags) != len(currentTags) {
+			action = "Set"
+			currentTags = tags
+			tagsUpdated = true
 		} else {
 			numNewTags := countNewTags(currentTags, tags)
 			if numNewTags > 0 {
+				action = "Set"
 				currentTags = tags
 				tagsUpdated = true
 			}
@@ -79,16 +78,10 @@ func (cm *CheckManager) AddMetricTags(metricName string, tags []string, appendTa
 	}
 
 	if tagsUpdated {
-		if len(currentTags) == 0 {
-			if _, exists := cm.metricTags[metricName]; exists {
-				delete(cm.metricTags, metricName)
-			}
-		} else {
-			cm.metricTags[metricName] = currentTags
-		}
+		cm.metricTags[metricName] = currentTags
 	}
 
-	if cm.Debug {
+	if cm.Debug && action != "" {
 		cm.Log.Printf("[DEBUG] %s metric tag(s) %s %v\n", action, metricName, tags)
 	}
 

--- a/checkmgr/metrics.go
+++ b/checkmgr/metrics.go
@@ -33,38 +33,59 @@ func (cm *CheckManager) ActivateMetric(name string) bool {
 func (cm *CheckManager) AddMetricTags(metricName string, tags []string, appendTags bool) bool {
 	tagsUpdated := false
 
-	if len(tags) == 0 {
+	if appendTags && len(tags) == 0 {
 		return tagsUpdated
 	}
 
-	if _, exists := cm.metricTags[metricName]; !exists {
+	currentTags, exists := cm.metricTags[metricName]
+	if !exists {
 		foundMetric := false
 
 		for _, metric := range cm.checkBundle.Metrics {
 			if metric.Name == metricName {
 				foundMetric = true
-				cm.metricTags[metricName] = metric.Tags
+				currentTags = metric.Tags
 				break
 			}
 		}
 
 		if !foundMetric {
-			cm.metricTags[metricName] = []string{}
+			currentTags = []string{}
 		}
 	}
 
 	action := "no new"
 	if appendTags {
-		numNewTags := countNewTags(cm.metricTags[metricName], tags)
+		numNewTags := countNewTags(currentTags, tags)
 		if numNewTags > 0 {
 			action = "Added"
-			cm.metricTags[metricName] = append(cm.metricTags[metricName], tags...)
+			currentTags = append(currentTags, tags...)
 			tagsUpdated = true
 		}
 	} else {
 		action = "Set"
-		cm.metricTags[metricName] = tags
-		tagsUpdated = true
+		if len(tags) == 0 {
+			if len(currentTags) > 0 {
+				currentTags = []string{}
+				tagsUpdated = true
+			}
+		} else {
+			numNewTags := countNewTags(currentTags, tags)
+			if numNewTags > 0 {
+				currentTags = tags
+				tagsUpdated = true
+			}
+		}
+	}
+
+	if tagsUpdated {
+		if len(currentTags) == 0 {
+			if _, exists := cm.metricTags[metricName]; exists {
+				delete(cm.metricTags, metricName)
+			}
+		} else {
+			cm.metricTags[metricName] = currentTags
+		}
 	}
 
 	if cm.Debug {

--- a/checkmgr/metrics_test.go
+++ b/checkmgr/metrics_test.go
@@ -5,6 +5,7 @@
 package checkmgr
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/circonus-labs/circonus-gometrics/api"
@@ -182,32 +183,63 @@ func TestAddMetricTags(t *testing.T) {
 
 	t.Log("metric named 'bar', add tag")
 	{
+
 		cm.metricTags = make(map[string][]string)
 		// append, zero current
 		if !cm.AddMetricTags("bar", []string{"cat:tag"}, true) {
 			t.Fatalf("Expected true")
 		}
-		if cm.metricTags["bar"][0] != "cat:tag" {
-			t.Fatalf("expected cat:tag")
+		expected := make(map[string][]string)
+		expected["bar"] = []string{"cat:tag"}
+
+		if !reflect.DeepEqual(cm.metricTags, expected) {
+			t.Fatalf("expected %v got %+v", expected, cm.metricTags)
 		}
+
 		// tag already exists, no need to add
 		if cm.AddMetricTags("bar", []string{"cat:tag"}, true) {
 			t.Fatalf("Expected false")
 		}
+
+		if !reflect.DeepEqual(cm.metricTags, expected) {
+			t.Fatalf("expected %v got %+v", expected, cm.metricTags)
+		}
+
 		// append, zero tags
 		if cm.AddMetricTags("bar", []string{}, true) {
 			t.Fatalf("Expected false")
+		}
+
+		if !reflect.DeepEqual(cm.metricTags, expected) {
+			t.Fatalf("expected %v got %+v", expected, cm.metricTags)
 		}
 	}
 
 	t.Log("metric named 'baz', add tag")
 	{
 		cm.metricTags = make(map[string][]string)
+
+		// append, current tag, should be noupdate
+		if cm.AddMetricTags("baz", []string{"cat1:tag1"}, true) {
+			t.Fatalf("Expected false")
+		}
+
+		if _, found := cm.metricTags["baz"]; found {
+			t.Fatalf("expected not found")
+		}
+
 		// append, one current
 		if !cm.AddMetricTags("baz", []string{"cat2:tag2"}, true) {
 			t.Fatalf("Expected true")
 		}
-		// append, tag already exists
+		expected := make(map[string][]string)
+		expected["baz"] = []string{"cat1:tag1", "cat2:tag2"}
+
+		if !reflect.DeepEqual(cm.metricTags, expected) {
+			t.Fatalf("expected %v got %+v", expected, cm.metricTags)
+		}
+
+		// append, tag already exists (should be noupdate)
 		if cm.AddMetricTags("baz", []string{"cat2:tag2"}, true) {
 			t.Fatalf("Expected false")
 		}
@@ -215,28 +247,57 @@ func TestAddMetricTags(t *testing.T) {
 
 	t.Log("metric named 'foo', set tag")
 	{
+		expected := make(map[string][]string)
 		cm.metricTags = make(map[string][]string)
 
 		// set tag
 		if !cm.AddMetricTags("foo", []string{"cat:tag"}, false) {
 			t.Fatalf("Expected true")
 		}
+		expected["foo"] = []string{"cat:tag"}
+		if !reflect.DeepEqual(cm.metricTags, expected) {
+			t.Fatalf("expected %v got %+v", expected, cm.metricTags)
+		}
+
 		// set, reset (pass 0 tags)
 		if !cm.AddMetricTags("foo", []string{}, false) {
 			t.Fatalf("Expected true")
 		}
+
+		if _, found := cm.metricTags["foo"]; found {
+			t.Fatal("expected not found")
+		}
+
 		// set tag
 		if !cm.AddMetricTags("foo", []string{"cat:tag"}, false) {
 			t.Fatalf("Expected true")
 		}
+
+		expected["foo"] = []string{"cat:tag"}
+		if !reflect.DeepEqual(cm.metricTags, expected) {
+			t.Fatalf("expected %v got %+v", expected, cm.metricTags)
+		}
+
 		// set, no update (same tag)
 		if cm.AddMetricTags("foo", []string{"cat:tag"}, false) {
 			t.Fatalf("Expected false")
 		}
+
+		expected["foo"] = []string{"cat:tag"}
+		if !reflect.DeepEqual(cm.metricTags, expected) {
+			t.Fatalf("expected %v got %+v", expected, cm.metricTags)
+		}
+
 		// replace any existing
 		if !cm.AddMetricTags("foo", []string{"cat:newtag"}, false) {
 			t.Fatalf("Expected true")
 		}
+
+		expected["foo"] = []string{"cat:newtag"}
+		if !reflect.DeepEqual(cm.metricTags, expected) {
+			t.Fatalf("expected %v got %+v", expected, cm.metricTags)
+		}
+
 	}
 }
 

--- a/checkmgr/metrics_test.go
+++ b/checkmgr/metrics_test.go
@@ -168,6 +168,11 @@ func TestAddMetricTags(t *testing.T) {
 			Status: "active",
 		},
 		api.CheckBundleMetric{
+			Name:   "foo",
+			Type:   "numeric",
+			Status: "active",
+		},
+		api.CheckBundleMetric{
 			Name:   "baz",
 			Type:   "numeric",
 			Status: "active",
@@ -177,25 +182,60 @@ func TestAddMetricTags(t *testing.T) {
 
 	t.Log("metric named 'bar', add tag")
 	{
+		cm.metricTags = make(map[string][]string)
 		// append, zero current
 		if !cm.AddMetricTags("bar", []string{"cat:tag"}, true) {
 			t.Fatalf("Expected true")
 		}
-		// replace any existing
-		if !cm.AddMetricTags("bar", []string{"cat:tag"}, false) {
-			t.Fatalf("Expected true")
+		if cm.metricTags["bar"][0] != "cat:tag" {
+			t.Fatalf("expected cat:tag")
+		}
+		// tag already exists, no need to add
+		if cm.AddMetricTags("bar", []string{"cat:tag"}, true) {
+			t.Fatalf("Expected false")
+		}
+		// append, zero tags
+		if cm.AddMetricTags("bar", []string{}, true) {
+			t.Fatalf("Expected false")
 		}
 	}
 
 	t.Log("metric named 'baz', add tag")
 	{
+		cm.metricTags = make(map[string][]string)
 		// append, one current
-		if !cm.AddMetricTags("baz", []string{"cat:tag"}, true) {
+		if !cm.AddMetricTags("baz", []string{"cat2:tag2"}, true) {
 			t.Fatalf("Expected true")
 		}
 		// append, tag already exists
-		if cm.AddMetricTags("baz", []string{"cat:tag"}, true) {
+		if cm.AddMetricTags("baz", []string{"cat2:tag2"}, true) {
 			t.Fatalf("Expected false")
+		}
+	}
+
+	t.Log("metric named 'foo', set tag")
+	{
+		cm.metricTags = make(map[string][]string)
+
+		// set tag
+		if !cm.AddMetricTags("foo", []string{"cat:tag"}, false) {
+			t.Fatalf("Expected true")
+		}
+		// set, reset (pass 0 tags)
+		if !cm.AddMetricTags("foo", []string{}, false) {
+			t.Fatalf("Expected true")
+		}
+		// set tag
+		if !cm.AddMetricTags("foo", []string{"cat:tag"}, false) {
+			t.Fatalf("Expected true")
+		}
+		// set, no update (same tag)
+		if cm.AddMetricTags("foo", []string{"cat:tag"}, false) {
+			t.Fatalf("Expected false")
+		}
+		// replace any existing
+		if !cm.AddMetricTags("foo", []string{"cat:newtag"}, false) {
+			t.Fatalf("Expected true")
 		}
 	}
 }

--- a/checkmgr/metrics_test.go
+++ b/checkmgr/metrics_test.go
@@ -264,8 +264,13 @@ func TestAddMetricTags(t *testing.T) {
 			t.Fatalf("Expected true")
 		}
 
-		if _, found := cm.metricTags["foo"]; found {
-			t.Fatal("expected not found")
+		if _, found := cm.metricTags["foo"]; !found {
+			t.Fatal("expected found")
+		}
+
+		expected["foo"] = []string{}
+		if !reflect.DeepEqual(cm.metricTags, expected) {
+			t.Fatalf("expected %v got %+v", expected, cm.metricTags)
 		}
 
 		// set tag

--- a/checkmgr/metrics_test.go
+++ b/checkmgr/metrics_test.go
@@ -17,6 +17,7 @@ func TestIsMetricActive(t *testing.T) {
 
 	cm.availableMetrics = map[string]bool{
 		"foo": true,
+		"baz": false,
 	}
 
 	t.Log("'foo' in active metric list")
@@ -29,6 +30,13 @@ func TestIsMetricActive(t *testing.T) {
 	t.Log("'bar' not in active metric list")
 	{
 		if cm.IsMetricActive("bar") {
+			t.Error("Expected false")
+		}
+	}
+
+	t.Log("'baz' in active metric list, not active")
+	{
+		if cm.IsMetricActive("baz") {
 			t.Error("Expected false")
 		}
 	}


### PR DESCRIPTION
bug resulting in redundant check update when there were not actually any new tags added to metrics.