### PR TITLE
Use `const` vs `var` for various package constants

### DIFF
--- a/api/broker.go
+++ b/api/broker.go
@@ -37,7 +37,7 @@ type Broker struct {
 	Type      string         `json:"_type"`
 }
 
-var baseBrokerPath = "/broker"
+const baseBrokerPath = "/broker"
 
 // FetchBrokerByID fetch a broker configuration by [group]id
 func (a *API) FetchBrokerByID(id IDType) (*Broker, error) {

--- a/api/check.go
+++ b/api/check.go
@@ -28,7 +28,7 @@ type Check struct {
 	Details        CheckDetails `json:"_details"`
 }
 
-var baseCheckPath = "/check"
+const baseCheckPath = "/check"
 
 // FetchCheckByID fetch a check configuration by id
 func (a *API) FetchCheckByID(id IDType) (*Check, error) {

--- a/api/check_bundle.go
+++ b/api/check_bundle.go
@@ -57,7 +57,7 @@ type CheckBundle struct {
 	Type               string              `json:"type"`
 }
 
-var baseCheckBundlePath = "/check_bundle"
+const baseCheckBundlePath = "/check_bundle"
 
 // FetchCheckBundleByID fetch a check bundle configuration by id
 func (a *API) FetchCheckBundleByID(id IDType) (*CheckBundle, error) {

--- a/api/metric_cluster.go
+++ b/api/metric_cluster.go
@@ -28,7 +28,7 @@ type MetricCluster struct {
 	Tags                []string            `json:"tags"`
 }
 
-var baseMetricClusterPath = "/metric_cluster"
+const baseMetricClusterPath = "/metric_cluster"
 
 // FetchMetricClusterByID fetch a metric cluster configuration by id
 func (a *API) FetchMetricClusterByID(id IDType, extras string) (*MetricCluster, error) {


### PR DESCRIPTION
Tiny nit that I came across.  Neither of these are written to or updated, nor should they be (if they need to, the updates should exist in a config object someplace).