### PR TITLE
Provide async initialization with exponential back off

### DIFF
--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -63,7 +63,7 @@ func main() {
 | General ||
 | `cfg.Log` | none | log.Logger instance to send logging messages. Default is to discard messages. If Debug is turned on and no instance is specified, messages will go to stderr. |
 | `cfg.Debug` | false | Turn on debugging messages. |
-| `cfg.Interval` | "10s" | Interval at which metrics are flushed and sent to Circonus. |
+| `cfg.Interval` | "10s" | Interval at which metrics are flushed and sent to Circonus. Set to "0s" to disable automatic flush (note, if disabled, `cgm.Flush()` must be called manually to send metrics to Circonus).|
 | `cfg.ResetCounters` | "true" | Reset counter metrics after each submission. Change to "false" to retain (and continue submitting) the last value.|
 | `cfg.ResetGauges` | "true" | Reset gauge metrics after each submission. Change to "false" to retain (and continue submitting) the last value.|
 | `cfg.ResetHistograms` | "true" | Reset histogram metrics after each submission. Change to "false" to retain (and continue submitting) the last value.|

--- a/README.md
+++ b/README.md
@@ -18,70 +18,67 @@ A working cut-n-past example. Simply set the required environment variable `CIRC
 package main
 
 import (
-	"log"
-	"math/rand"
-	"os"
+    "log"
+    "math/rand"
+    "os"
     "os/signal"
     "syscall"
-	"time"
+    "time"
 
-	cgm "github.com/circonus-labs/circonus-gometrics"
+    cgm "github.com/circonus-labs/circonus-gometrics"
 )
 
 func main() {
 
     logger := log.New(os.Stdout, "", log.LstdFlags)
 
-	logger.Println("Configuring cgm")
+    logger.Println("Configuring cgm")
 
-	cmc := &cgm.Config{}
+    cmc := &cgm.Config{}
     cmc.Debug := false // set to true for debug messages
-	cmc.Log = logger
+    cmc.Log = logger
 
-	// Circonus API Token key (https://login.circonus.com/user/tokens)
-	cmc.CheckManager.API.TokenKey = os.Getenv("CIRCONUS_API_TOKEN")
+    // Circonus API Token key (https://login.circonus.com/user/tokens)
+    cmc.CheckManager.API.TokenKey = os.Getenv("CIRCONUS_API_TOKEN")
 
-	logger.Println("Creating new cgm instance")
+    logger.Println("Creating new cgm instance")
 
-	metrics, err := cgm.NewCirconusMetrics(cmc)
-	if err != nil {
+    metrics, err := cgm.NewCirconusMetrics(cmc)
+    if err != nil {
         logger.Println(err)
-		os.Exit(1)
-	}
+        os.Exit(1)
+    }
 
-	src := rand.NewSource(time.Now().UnixNano())
-	rnd := rand.New(src)
-
-	logger.Println("Starting cgm internal auto-flush timer")
-	metrics.Start()
+    src := rand.NewSource(time.Now().UnixNano())
+    rnd := rand.New(src)
 
     logger.Println("Adding ctrl-c trap")
-	c := make(chan os.Signal, 2)
-	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
-	go func() {
-		<-c
-		logger.Println("Received CTRL-C, flushing outstanding metrics before exit")
-		metrics.Flush()
-		os.Exit(0)
-	}()
+    c := make(chan os.Signal, 2)
+    signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+    go func() {
+        <-c
+        logger.Println("Received CTRL-C, flushing outstanding metrics before exit")
+        metrics.Flush()
+        os.Exit(0)
+    }()
 
-	logger.Println("Starting to send metrics")
+    logger.Println("Starting to send metrics")
 
-	// number of "sets" of metrics to send
-	max := 60
+    // number of "sets" of metrics to send
+    max := 60
 
-	for i := 1; i < max; i++ {
-		logger.Printf("\tmetric set %d of %d", i, 60)
-		metrics.Timing("foo", rnd.Float64()*10)
-		metrics.Increment("bar")
-		metrics.Gauge("baz", 10)
+    for i := 1; i < max; i++ {
+        logger.Printf("\tmetric set %d of %d", i, 60)
+        metrics.Timing("foo", rnd.Float64()*10)
+        metrics.Increment("bar")
+        metrics.Gauge("baz", 10)
         time.Sleep(time.Second)
-	}
+    }
 
     metrics.SetText("fini", "complete")
 
-	logger.Println("Flushing any outstanding metrics manually")
-	metrics.Flush()
+    logger.Println("Flushing any outstanding metrics manually")
+    metrics.Flush()
 }
 ```
 
@@ -93,98 +90,95 @@ A working, cut-n-paste example with all options available for modification. Also
 package main
 
 import (
-	"log"
-	"math/rand"
-	"os"
+    "log"
+    "math/rand"
+    "os"
     "os/signal"
     "syscall"
-	"time"
+    "time"
 
-	cgm "github.com/circonus-labs/circonus-gometrics"
+    cgm "github.com/circonus-labs/circonus-gometrics"
 )
 
 func main() {
 
     logger := log.New(os.Stdout, "", log.LstdFlags)
 
-	logger.Println("Configuring cgm")
+    logger.Println("Configuring cgm")
 
-	cmc := &cgm.Config{}
+    cmc := &cgm.Config{}
 
     // General
 
-	cmc.Interval = "10s"
+    cmc.Interval = "10s"
     cmc.Log = logger
-	cmc.Debug = false
+    cmc.Debug = false
     cmc.ResetCounters = "true"
     cmc.ResetGauges = "true"
     cmc.ResetHistograms = "true"
     cmc.ResetText = "true"
 
-	// Circonus API configuration options
-	cmc.CheckManager.API.TokenKey = os.Getenv("CIRCONUS_API_TOKEN")
-	cmc.CheckManager.API.TokenApp = os.Getenv("CIRCONUS_API_APP")
-	cmc.CheckManager.API.URL = os.Getenv("CIRCONUS_API_URL")
+    // Circonus API configuration options
+    cmc.CheckManager.API.TokenKey = os.Getenv("CIRCONUS_API_TOKEN")
+    cmc.CheckManager.API.TokenApp = os.Getenv("CIRCONUS_API_APP")
+    cmc.CheckManager.API.URL = os.Getenv("CIRCONUS_API_URL")
 
-	// Check configuration options
-	cmc.CheckManager.Check.SubmissionURL = os.Getenv("CIRCONUS_SUBMISION_URL")
-	cmc.CheckManager.Check.ID = os.Getenv("CIRCONUS_CHECK_ID")
-	cmc.CheckManager.Check.InstanceID = ""
-	cmc.CheckManager.Check.DisplayName = ""
+    // Check configuration options
+    cmc.CheckManager.Check.SubmissionURL = os.Getenv("CIRCONUS_SUBMISION_URL")
+    cmc.CheckManager.Check.ID = os.Getenv("CIRCONUS_CHECK_ID")
+    cmc.CheckManager.Check.InstanceID = ""
+    cmc.CheckManager.Check.DisplayName = ""
     cmc.CheckManager.Check.TargetHost = ""
     //  if hn, err := os.Hostname(); err == nil {
     //      cmc.CheckManager.Check.TargetHost = hn
     //  }
-	cmc.CheckManager.Check.SearchTag = ""
-	cmc.CheckManager.Check.Secret = ""
-	cmc.CheckManager.Check.Tags = ""
-	cmc.CheckManager.Check.MaxURLAge = "5m"
-	cmc.CheckManager.Check.ForceMetricActivation = "false"
+    cmc.CheckManager.Check.SearchTag = ""
+    cmc.CheckManager.Check.Secret = ""
+    cmc.CheckManager.Check.Tags = ""
+    cmc.CheckManager.Check.MaxURLAge = "5m"
+    cmc.CheckManager.Check.ForceMetricActivation = "false"
 
-	// Broker configuration options
-	cmc.CheckManager.Broker.ID = ""
-	cmc.CheckManager.Broker.SelectTag = ""
-	cmc.CheckManager.Broker.MaxResponseTime = "500ms"
+    // Broker configuration options
+    cmc.CheckManager.Broker.ID = ""
+    cmc.CheckManager.Broker.SelectTag = ""
+    cmc.CheckManager.Broker.MaxResponseTime = "500ms"
 
-	logger.Println("Creating new cgm instance")
+    logger.Println("Creating new cgm instance")
 
-	metrics, err := cgm.NewCirconusMetrics(cmc)
-	if err != nil {
+    metrics, err := cgm.NewCirconusMetrics(cmc)
+    if err != nil {
         logger.Println(err)
-		os.Exit(1)
-	}
+        os.Exit(1)
+    }
 
-	src := rand.NewSource(time.Now().UnixNano())
-	rnd := rand.New(src)
-
-	logger.Println("Starting cgm internal auto-flush timer")
-	metrics.Start()
+    src := rand.NewSource(time.Now().UnixNano())
+    rnd := rand.New(src)
 
     logger.Println("Adding ctrl-c trap")
-	c := make(chan os.Signal, 2)
-	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
-	go func() {
-		<-c
-		logger.Println("Received CTRL-C, flushing outstanding metrics before exit")
-		metrics.Flush()
-		os.Exit(0)
-	}()
+    c := make(chan os.Signal, 2)
+    signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+    go func() {
+        <-c
+        logger.Println("Received CTRL-C, flushing outstanding metrics before exit")
+        metrics.Flush()
+        os.Exit(0)
+    }()
 
     // Add metric tags (append to any existing tags on specified metric)
     metrics.AddMetricTags("foo", []string{"cgm:test"})
     metrics.AddMetricTags("baz", []string{"cgm:test"})
 
-	logger.Println("Starting to send metrics")
+    logger.Println("Starting to send metrics")
 
-	// number of "sets" of metrics to send
-	max := 60
+    // number of "sets" of metrics to send
+    max := 60
 
-	for i := 1; i < max; i++ {
-		logger.Printf("\tmetric set %d of %d", i, 60)
+    for i := 1; i < max; i++ {
+        logger.Printf("\tmetric set %d of %d", i, 60)
 
-		metrics.Timing("foo", rnd.Float64()*10)
-		metrics.Increment("bar")
-		metrics.Gauge("baz", 10)
+        metrics.Timing("foo", rnd.Float64()*10)
+        metrics.Increment("bar")
+        metrics.Gauge("baz", 10)
 
         if i == 35 {
             // Set metric tags (overwrite current tags on specified metric)
@@ -192,10 +186,10 @@ func main() {
         }
 
         time.Sleep(time.Second)
-	}
+    }
 
-	logger.Println("Flushing any outstanding metrics manually")
-	metrics.Flush()
+    logger.Println("Flushing any outstanding metrics manually")
+    metrics.Flush()
 
 }
 ```
@@ -226,7 +220,6 @@ func main() {
     if err != nil {
         panic(err)
     }
-    metrics.Start()
 
     http.HandleFunc("/", metrics.TrackHTTPLatency("/", func(w http.ResponseWriter, r *http.Request) {
         fmt.Fprintf(w, "Hello, %s!", r.URL.Path[1:])

--- a/api/api.go
+++ b/api/api.go
@@ -17,6 +17,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
@@ -197,6 +198,9 @@ func (a *API) apiRequest(reqMethod string, reqPath string, data []byte) ([]byte,
 		// break and return error if not using exponential backoff
 		if err != nil {
 			if !a.useExponentialBackoff {
+				break
+			}
+			if matched, _ := regexp.MatchString("code 403", err.Error()); matched {
 				break
 			}
 		}

--- a/api/api.go
+++ b/api/api.go
@@ -6,11 +6,13 @@ package api
 
 import (
 	"bytes"
+	crand "crypto/rand"
 	"errors"
 	"fmt"
 	"io/ioutil"
 	"log"
 	"math"
+	"math/big"
 	"math/rand"
 	"net/http"
 	"net/url"
@@ -22,7 +24,12 @@ import (
 )
 
 func init() {
-	rand.Seed(time.Now().Unix())
+	n, err := crand.Int(crand.Reader, big.NewInt(math.MaxInt64))
+	if err != nil {
+		rand.Seed(time.Now().UTC().UnixNano())
+		return
+	}
+	rand.Seed(n.Int64())
 }
 
 const (

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 func callServer() *httptest.Server {
@@ -17,6 +18,26 @@ func callServer() *httptest.Server {
 		w.WriteHeader(200)
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprintln(w, r.Method)
+	}
+
+	return httptest.NewServer(http.HandlerFunc(f))
+}
+
+var (
+	numReq = 0
+	maxReq = 2
+)
+
+func retryCallServer() *httptest.Server {
+	f := func(w http.ResponseWriter, r *http.Request) {
+		numReq++
+		if numReq > maxReq {
+			w.WriteHeader(200)
+		} else {
+			w.WriteHeader(500)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, "blah blah blah, error...")
 	}
 
 	return httptest.NewServer(http.HandlerFunc(f))
@@ -234,7 +255,6 @@ func TestApiCall(t *testing.T) {
 			t.Errorf("Expected\n'%s'\ngot\n'%s'\n", expected, resp)
 		}
 	}
-
 }
 
 func TestApiGet(t *testing.T) {
@@ -347,4 +367,68 @@ func TestApiDelete(t *testing.T) {
 		t.Errorf("Expected\n'%s'\ngot\n'%s'\n", expected, resp)
 	}
 
+}
+
+func TestApiRequest(t *testing.T) {
+	server := retryCallServer()
+	defer server.Close()
+
+	ac := &Config{
+		TokenKey: "foo",
+		TokenApp: "bar",
+		URL:      server.URL,
+	}
+
+	apih, err := NewAPI(ac)
+	if err != nil {
+		t.Errorf("Expected no error, got '%+v'", err)
+	}
+
+	t.Log("Testing api request retries, this may take a few...")
+
+	apih.DisableExponentialBackoff()
+
+	t.Log("drift retry")
+	{
+		calls := []string{"GET", "PUT", "POST", "DELETE"}
+		for _, call := range calls {
+			t.Logf("\tTesting %d %s call(s)", maxReq, call)
+			numReq = 0
+			start := time.Now()
+			resp, err := apih.apiRequest(call, "/", nil)
+			if err != nil {
+				t.Errorf("Expected no error, got '%+v'", resp)
+			}
+			elapsed := time.Since(start)
+			t.Log("\tTime: ", elapsed)
+
+			expected := "blah blah blah, error...\n"
+			if string(resp) != expected {
+				t.Errorf("Expected\n'%s'\ngot\n'%s'\n", expected, resp)
+			}
+		}
+	}
+
+	apih.EnableExponentialBackoff()
+
+	t.Log("exponential backoff")
+	{
+		calls := []string{"GET", "PUT", "POST", "DELETE"}
+		for _, call := range calls {
+			t.Logf("\tTesting %d %s call(s)", maxReq, call)
+			numReq = 0
+			start := time.Now()
+			resp, err := apih.apiRequest(call, "/", nil)
+			if err != nil {
+				t.Errorf("Expected no error, got '%+v'", resp)
+			}
+			elapsed := time.Since(start)
+			t.Log("\tTime: ", elapsed)
+
+			expected := "blah blah blah, error...\n"
+			if string(resp) != expected {
+				t.Errorf("Expected\n'%s'\ngot\n'%s'\n", expected, resp)
+			}
+		}
+	}
 }

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -140,6 +140,34 @@ func TestNew(t *testing.T) {
 	}
 }
 
+func TestEnableExponentialBackoff(t *testing.T) {
+	ac := &Config{
+		TokenKey: "foo",
+		TokenApp: "bar",
+	}
+
+	apih, err := NewAPI(ac)
+	if err != nil {
+		t.Errorf("Expected no error, got '%+v'", err)
+	}
+
+	apih.EnableExponentialBackoff()
+}
+
+func TestDisableExponentialBackoff(t *testing.T) {
+	ac := &Config{
+		TokenKey: "foo",
+		TokenApp: "bar",
+	}
+
+	apih, err := NewAPI(ac)
+	if err != nil {
+		t.Errorf("Expected no error, got '%+v'", err)
+	}
+
+	apih.DisableExponentialBackoff()
+}
+
 func TestApiCall(t *testing.T) {
 	server := callServer()
 	defer server.Close()

--- a/checkmgr/checkmgr_test.go
+++ b/checkmgr/checkmgr_test.go
@@ -15,6 +15,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/circonus-labs/circonus-gometrics/api"
 	"github.com/circonus-labs/circonus-gometrics/api/config"
@@ -243,7 +244,14 @@ func TestNewCheckManager(t *testing.T) {
 			t.Errorf("Expected no error, got '%v'", err)
 		}
 
-		trap, err := cm.GetTrap()
+		cm.Initialize()
+
+		for !cm.IsReady() {
+			t.Log("\twaiting for cm to init")
+			time.Sleep(1 * time.Second)
+		}
+
+		trap, err := cm.GetSubmissionURL()
 		if err != nil {
 			t.Errorf("Expected no error, got '%v'", err)
 		}
@@ -267,7 +275,14 @@ func TestNewCheckManager(t *testing.T) {
 			t.Fatalf("Expected no error, got '%v'", err)
 		}
 
-		trap, err := cm.GetTrap()
+		cm.Initialize()
+
+		for !cm.IsReady() {
+			t.Log("\twaiting for cm to init")
+			time.Sleep(1 * time.Second)
+		}
+
+		trap, err := cm.GetSubmissionURL()
 		if err != nil {
 			t.Fatalf("Expected no error, got '%v'", err)
 		}
@@ -312,7 +327,15 @@ func TestNewCheckManager(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Expected no error, got '%v'", err)
 		}
-		trap, err := cm.GetTrap()
+
+		cm.Initialize()
+
+		for !cm.IsReady() {
+			t.Log("\twaiting for cm to init")
+			time.Sleep(1 * time.Second)
+		}
+
+		trap, err := cm.GetSubmissionURL()
 		if err != nil {
 			t.Fatalf("Expected no error, got '%v'", err)
 		}

--- a/checkmgr/metrics.go
+++ b/checkmgr/metrics.go
@@ -41,11 +41,13 @@ func (cm *CheckManager) AddMetricTags(metricName string, tags []string, appendTa
 	if !exists {
 		foundMetric := false
 
-		for _, metric := range cm.checkBundle.Metrics {
-			if metric.Name == metricName {
-				foundMetric = true
-				currentTags = metric.Tags
-				break
+		if cm.checkBundle != nil {
+			for _, metric := range cm.checkBundle.Metrics {
+				if metric.Name == metricName {
+					foundMetric = true
+					currentTags = metric.Tags
+					break
+				}
 			}
 		}
 

--- a/circonus-gometrics.go
+++ b/circonus-gometrics.go
@@ -65,9 +65,9 @@ type Config struct {
 
 // CirconusMetrics state
 type CirconusMetrics struct {
-	Log             *log.Logger
-	Debug           bool
-	initialized     bool
+	Log   *log.Logger
+	Debug bool
+
 	resetCounters   bool
 	resetGauges     bool
 	resetHistograms bool
@@ -198,8 +198,11 @@ func New(cfg *Config) (*CirconusMetrics, error) {
 		cm.check = check
 	}
 
+	// start background initialization
 	cm.check.Initialize()
 
+	// if automatic flush is enabled, start it.
+	// note: submit will jettison metrics until initialization has completed.
 	if cm.flushInterval > time.Duration(0) {
 		go func() {
 			for _ = range time.NewTicker(cm.flushInterval).C {

--- a/circonus-gometrics_test.go
+++ b/circonus-gometrics_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 func testServer() *httptest.Server {
@@ -90,7 +91,12 @@ func TestNew(t *testing.T) {
 			t.Fatalf("Expected no error, got '%v'", err)
 		}
 
-		trap, err := cm.check.GetTrap()
+		for !cm.check.IsReady() {
+			t.Log("\twaiting for cm to init")
+			time.Sleep(1 * time.Second)
+		}
+
+		trap, err := cm.check.GetSubmissionURL()
 		if err != nil {
 			t.Fatalf("Expected no error, got '%v'", err)
 		}

--- a/counter_test.go
+++ b/counter_test.go
@@ -11,8 +11,7 @@ import (
 func TestSet(t *testing.T) {
 	t.Log("Testing counter.Set")
 
-	cm := &CirconusMetrics{}
-	cm.counters = make(map[string]uint64)
+	cm := &CirconusMetrics{counters: make(map[string]uint64)}
 
 	cm.Set("foo", 30)
 
@@ -40,8 +39,8 @@ func TestSet(t *testing.T) {
 func TestIncrement(t *testing.T) {
 	t.Log("Testing counter.Increment")
 
-	cm := &CirconusMetrics{}
-	cm.counters = make(map[string]uint64)
+	cm := &CirconusMetrics{counters: make(map[string]uint64)}
+
 	cm.Increment("foo")
 
 	val, ok := cm.counters["foo"]
@@ -57,8 +56,8 @@ func TestIncrement(t *testing.T) {
 func TestIncrementByValue(t *testing.T) {
 	t.Log("Testing counter.IncrementByValue")
 
-	cm := &CirconusMetrics{}
-	cm.counters = make(map[string]uint64)
+	cm := &CirconusMetrics{counters: make(map[string]uint64)}
+
 	cm.IncrementByValue("foo", 10)
 
 	val, ok := cm.counters["foo"]
@@ -74,8 +73,8 @@ func TestIncrementByValue(t *testing.T) {
 func TestAdd(t *testing.T) {
 	t.Log("Testing counter.Add")
 
-	cm := &CirconusMetrics{}
-	cm.counters = make(map[string]uint64)
+	cm := &CirconusMetrics{counters: make(map[string]uint64)}
+
 	cm.Add("foo", 5)
 
 	val, ok := cm.counters["foo"]
@@ -91,8 +90,8 @@ func TestAdd(t *testing.T) {
 func TestRemoveCounter(t *testing.T) {
 	t.Log("Testing counter.RemoveCounter")
 
-	cm := &CirconusMetrics{}
-	cm.counters = make(map[string]uint64)
+	cm := &CirconusMetrics{counters: make(map[string]uint64)}
+
 	cm.Increment("foo")
 
 	val, ok := cm.counters["foo"]
@@ -122,8 +121,9 @@ func TestSetCounterFunc(t *testing.T) {
 	cf := func() uint64 {
 		return 1
 	}
-	cm := &CirconusMetrics{}
-	cm.counterFuncs = make(map[string]func() uint64)
+
+	cm := &CirconusMetrics{counterFuncs: make(map[string]func() uint64)}
+
 	cm.SetCounterFunc("foo", cf)
 
 	val, ok := cm.counterFuncs["foo"]
@@ -142,8 +142,9 @@ func TestRemoveCounterFunc(t *testing.T) {
 	cf := func() uint64 {
 		return 1
 	}
-	cm := &CirconusMetrics{}
-	cm.counterFuncs = make(map[string]func() uint64)
+
+	cm := &CirconusMetrics{counterFuncs: make(map[string]func() uint64)}
+
 	cm.SetCounterFunc("foo", cf)
 
 	val, ok := cm.counterFuncs["foo"]

--- a/gauge_test.go
+++ b/gauge_test.go
@@ -11,8 +11,7 @@ import (
 func TestGauge(t *testing.T) {
 	t.Log("int")
 	{
-		cm := &CirconusMetrics{}
-		cm.gauges = make(map[string]string)
+		cm := &CirconusMetrics{gauges: make(map[string]string)}
 
 		cm.Gauge("foo", int(1))
 		val, ok := cm.gauges["foo"]
@@ -27,8 +26,7 @@ func TestGauge(t *testing.T) {
 
 	t.Log("int8")
 	{
-		cm := &CirconusMetrics{}
-		cm.gauges = make(map[string]string)
+		cm := &CirconusMetrics{gauges: make(map[string]string)}
 
 		cm.Gauge("foo", int8(1))
 		val, ok := cm.gauges["foo"]
@@ -43,8 +41,7 @@ func TestGauge(t *testing.T) {
 
 	t.Log("int16")
 	{
-		cm := &CirconusMetrics{}
-		cm.gauges = make(map[string]string)
+		cm := &CirconusMetrics{gauges: make(map[string]string)}
 
 		cm.Gauge("foo", int16(1))
 		val, ok := cm.gauges["foo"]
@@ -59,8 +56,7 @@ func TestGauge(t *testing.T) {
 
 	t.Log("int32")
 	{
-		cm := &CirconusMetrics{}
-		cm.gauges = make(map[string]string)
+		cm := &CirconusMetrics{gauges: make(map[string]string)}
 
 		cm.Gauge("foo", int32(1))
 		val, ok := cm.gauges["foo"]
@@ -75,8 +71,7 @@ func TestGauge(t *testing.T) {
 
 	t.Log("int64")
 	{
-		cm := &CirconusMetrics{}
-		cm.gauges = make(map[string]string)
+		cm := &CirconusMetrics{gauges: make(map[string]string)}
 
 		cm.Gauge("foo", int64(1))
 		val, ok := cm.gauges["foo"]
@@ -91,8 +86,7 @@ func TestGauge(t *testing.T) {
 
 	t.Log("uint")
 	{
-		cm := &CirconusMetrics{}
-		cm.gauges = make(map[string]string)
+		cm := &CirconusMetrics{gauges: make(map[string]string)}
 
 		cm.Gauge("foo", uint(1))
 		val, ok := cm.gauges["foo"]
@@ -107,8 +101,7 @@ func TestGauge(t *testing.T) {
 
 	t.Log("uint8")
 	{
-		cm := &CirconusMetrics{}
-		cm.gauges = make(map[string]string)
+		cm := &CirconusMetrics{gauges: make(map[string]string)}
 
 		cm.Gauge("foo", uint8(1))
 		val, ok := cm.gauges["foo"]
@@ -123,8 +116,7 @@ func TestGauge(t *testing.T) {
 
 	t.Log("uint16")
 	{
-		cm := &CirconusMetrics{}
-		cm.gauges = make(map[string]string)
+		cm := &CirconusMetrics{gauges: make(map[string]string)}
 
 		cm.Gauge("foo", uint16(1))
 		val, ok := cm.gauges["foo"]
@@ -139,8 +131,7 @@ func TestGauge(t *testing.T) {
 
 	t.Log("uint32")
 	{
-		cm := &CirconusMetrics{}
-		cm.gauges = make(map[string]string)
+		cm := &CirconusMetrics{gauges: make(map[string]string)}
 
 		cm.Gauge("foo", uint32(1))
 		val, ok := cm.gauges["foo"]
@@ -155,8 +146,7 @@ func TestGauge(t *testing.T) {
 
 	t.Log("uint64")
 	{
-		cm := &CirconusMetrics{}
-		cm.gauges = make(map[string]string)
+		cm := &CirconusMetrics{gauges: make(map[string]string)}
 
 		cm.Gauge("foo", uint64(1))
 		val, ok := cm.gauges["foo"]
@@ -171,8 +161,7 @@ func TestGauge(t *testing.T) {
 
 	t.Log("float32")
 	{
-		cm := &CirconusMetrics{}
-		cm.gauges = make(map[string]string)
+		cm := &CirconusMetrics{gauges: make(map[string]string)}
 
 		cm.Gauge("foo", float32(3.12))
 		val, ok := cm.gauges["foo"]
@@ -187,8 +176,7 @@ func TestGauge(t *testing.T) {
 
 	t.Log("float64")
 	{
-		cm := &CirconusMetrics{}
-		cm.gauges = make(map[string]string)
+		cm := &CirconusMetrics{gauges: make(map[string]string)}
 
 		cm.Gauge("foo", float64(3.12))
 		val, ok := cm.gauges["foo"]
@@ -205,8 +193,8 @@ func TestGauge(t *testing.T) {
 func TestSetGauge(t *testing.T) {
 	t.Log("Testing gauge.SetGauge")
 
-	cm := &CirconusMetrics{}
-	cm.gauges = make(map[string]string)
+	cm := &CirconusMetrics{gauges: make(map[string]string)}
+
 	cm.SetGauge("foo", 10)
 
 	val, ok := cm.gauges["foo"]
@@ -222,8 +210,8 @@ func TestSetGauge(t *testing.T) {
 func TestRemoveGauge(t *testing.T) {
 	t.Log("Testing gauge.RemoveGauge")
 
-	cm := &CirconusMetrics{}
-	cm.gauges = make(map[string]string)
+	cm := &CirconusMetrics{gauges: make(map[string]string)}
+
 	cm.Gauge("foo", 5)
 
 	val, ok := cm.gauges["foo"]
@@ -253,8 +241,9 @@ func TestSetGaugeFunc(t *testing.T) {
 	gf := func() int64 {
 		return 1
 	}
-	cm := &CirconusMetrics{}
-	cm.gaugeFuncs = make(map[string]func() int64)
+
+	cm := &CirconusMetrics{gaugeFuncs: make(map[string]func() int64)}
+
 	cm.SetGaugeFunc("foo", gf)
 
 	val, ok := cm.gaugeFuncs["foo"]
@@ -273,8 +262,9 @@ func TestRemoveGaugeFunc(t *testing.T) {
 	gf := func() int64 {
 		return 1
 	}
-	cm := &CirconusMetrics{}
-	cm.gaugeFuncs = make(map[string]func() int64)
+
+	cm := &CirconusMetrics{gaugeFuncs: make(map[string]func() int64)}
+
 	cm.SetGaugeFunc("foo", gf)
 
 	val, ok := cm.gaugeFuncs["foo"]

--- a/histogram_test.go
+++ b/histogram_test.go
@@ -12,8 +12,8 @@ import (
 func TestTiming(t *testing.T) {
 	t.Log("Testing histogram.Timing")
 
-	cm := &CirconusMetrics{}
-	cm.histograms = make(map[string]*Histogram)
+	cm := &CirconusMetrics{histograms: make(map[string]*Histogram)}
+
 	cm.Timing("foo", 1)
 
 	hist, ok := cm.histograms["foo"]
@@ -39,8 +39,8 @@ func TestTiming(t *testing.T) {
 func TestRecordValue(t *testing.T) {
 	t.Log("Testing histogram.RecordValue")
 
-	cm := &CirconusMetrics{}
-	cm.histograms = make(map[string]*Histogram)
+	cm := &CirconusMetrics{histograms: make(map[string]*Histogram)}
+
 	cm.RecordValue("foo", 1)
 
 	hist, ok := cm.histograms["foo"]
@@ -66,8 +66,8 @@ func TestRecordValue(t *testing.T) {
 func TestSetHistogramValue(t *testing.T) {
 	t.Log("Testing histogram.SetHistogramValue")
 
-	cm := &CirconusMetrics{}
-	cm.histograms = make(map[string]*Histogram)
+	cm := &CirconusMetrics{histograms: make(map[string]*Histogram)}
+
 	cm.SetHistogramValue("foo", 1)
 
 	hist, ok := cm.histograms["foo"]
@@ -93,8 +93,8 @@ func TestSetHistogramValue(t *testing.T) {
 func TestRemoveHistogram(t *testing.T) {
 	t.Log("Testing histogram.RemoveHistogram")
 
-	cm := &CirconusMetrics{}
-	cm.histograms = make(map[string]*Histogram)
+	cm := &CirconusMetrics{histograms: make(map[string]*Histogram)}
+
 	cm.SetHistogramValue("foo", 1)
 
 	hist, ok := cm.histograms["foo"]
@@ -131,8 +131,8 @@ func TestRemoveHistogram(t *testing.T) {
 func TestNewHistogram(t *testing.T) {
 	t.Log("Testing histogram.NewHistogram")
 
-	cm := &CirconusMetrics{}
-	cm.histograms = make(map[string]*Histogram)
+	cm := &CirconusMetrics{histograms: make(map[string]*Histogram)}
+
 	hist := cm.NewHistogram("foo")
 
 	actualType := reflect.TypeOf(hist)
@@ -145,8 +145,8 @@ func TestNewHistogram(t *testing.T) {
 func TestHistName(t *testing.T) {
 	t.Log("Testing hist.Name")
 
-	cm := &CirconusMetrics{}
-	cm.histograms = make(map[string]*Histogram)
+	cm := &CirconusMetrics{histograms: make(map[string]*Histogram)}
+
 	hist := cm.NewHistogram("foo")
 
 	actualType := reflect.TypeOf(hist)
@@ -165,8 +165,8 @@ func TestHistName(t *testing.T) {
 func TestHistRecordValue(t *testing.T) {
 	t.Log("Testing hist.RecordValue")
 
-	cm := &CirconusMetrics{}
-	cm.histograms = make(map[string]*Histogram)
+	cm := &CirconusMetrics{histograms: make(map[string]*Histogram)}
+
 	hist := cm.NewHistogram("foo")
 
 	actualType := reflect.TypeOf(hist)

--- a/submit.go
+++ b/submit.go
@@ -22,6 +22,12 @@ import (
 
 func (m *CirconusMetrics) submit(output map[string]interface{}, newMetrics map[string]*api.CheckBundleMetric) {
 
+	// if there is nowhere to send metrics to, just return.
+	if !m.check.IsReady() {
+		m.Log.Printf("[WARN] check not ready, skipping metric submission")
+		return
+	}
+
 	// update check if there are any new metrics or, if metric tags have been added since last submit
 	m.check.UpdateCheck(newMetrics)
 
@@ -43,7 +49,7 @@ func (m *CirconusMetrics) submit(output map[string]interface{}, newMetrics map[s
 }
 
 func (m *CirconusMetrics) trapCall(payload []byte) (int, error) {
-	trap, err := m.check.GetTrap()
+	trap, err := m.check.GetSubmissionURL()
 	if err != nil {
 		return 0, err
 	}

--- a/submit_test.go
+++ b/submit_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/circonus-labs/circonus-gometrics/api"
 )
@@ -59,6 +60,11 @@ func TestTrapCall(t *testing.T) {
 	cm, err := NewCirconusMetrics(cfg)
 	if err != nil {
 		t.Errorf("Expected no error, got '%v'", err)
+	}
+
+	for !cm.check.IsReady() {
+		t.Log("\twaiting for cm to init")
+		time.Sleep(1 * time.Second)
 	}
 
 	output := make(map[string]interface{})


### PR DESCRIPTION
1. Switch cgm.New() to initialize in the background with exponential back off: 2, 4, 8, 16, 32, 32, ...
1. Accept metrics while initializing.
1. If a flush occurs before initialization, drop the metrics (nowhere to send them).
1. If a log.Logger instance is NOT provided in cgm.Config{Log:...} this process will be silent.