### PR TITLE
Address race conditions

### DIFF
--- a/checkmgr/checkmgr.go
+++ b/checkmgr/checkmgr.go
@@ -140,7 +140,8 @@ type CheckManager struct {
 	Debug   bool
 	apih    *api.API
 
-	initialized bool
+	initialized   bool
+	initializedmu sync.RWMutex
 
 	// check
 	checkType             CheckTypeType
@@ -333,7 +334,9 @@ func (cm *CheckManager) Initialize() {
 		}
 		err := cm.initializeTrapURL()
 		if err == nil {
+			cm.initializedmu.Lock()
 			cm.initialized = true
+			cm.initializedmu.Unlock()
 		} else {
 			fmt.Printf("[WARN] error initializing trap %s", err.Error())
 		}
@@ -345,6 +348,8 @@ func (cm *CheckManager) Initialize() {
 
 // IsReady reflects if the check has been initialied and metrics can be sent to Circonus
 func (cm *CheckManager) IsReady() bool {
+	cm.initializedmu.RLock()
+	defer cm.initializedmu.RUnlock()
 	return cm.initialized
 }
 

--- a/checkmgr/checkmgr.go
+++ b/checkmgr/checkmgr.go
@@ -166,15 +166,16 @@ type CheckManager struct {
 	brokerMaxResponseTime time.Duration
 
 	// state
-	checkBundle      *api.CheckBundle
-	cbmu             sync.Mutex
-	availableMetrics map[string]bool
-	trapURL          api.URLType
-	trapCN           BrokerCNType
-	trapLastUpdate   time.Time
-	trapMaxURLAge    time.Duration
-	trapmu           sync.Mutex
-	certPool         *x509.CertPool
+	checkBundle        *api.CheckBundle
+	cbmu               sync.Mutex
+	availableMetrics   map[string]bool
+	availableMetricsmu sync.Mutex
+	trapURL            api.URLType
+	trapCN             BrokerCNType
+	trapLastUpdate     time.Time
+	trapMaxURLAge      time.Duration
+	trapmu             sync.Mutex
+	certPool           *x509.CertPool
 }
 
 // Trap config

--- a/checkmgr/metrics.go
+++ b/checkmgr/metrics.go
@@ -10,12 +10,18 @@ import (
 
 // IsMetricActive checks whether a given metric name is currently active(enabled)
 func (cm *CheckManager) IsMetricActive(name string) bool {
+	cm.availableMetricsmu.Lock()
+	defer cm.availableMetricsmu.Unlock()
+
 	active, _ := cm.availableMetrics[name]
 	return active
 }
 
 // ActivateMetric determines if a given metric should be activated
 func (cm *CheckManager) ActivateMetric(name string) bool {
+	cm.availableMetricsmu.Lock()
+	defer cm.availableMetricsmu.Unlock()
+
 	active, exists := cm.availableMetrics[name]
 
 	if !exists {
@@ -132,7 +138,9 @@ func (cm *CheckManager) inventoryMetrics() {
 	for _, metric := range cm.checkBundle.Metrics {
 		availableMetrics[metric.Name] = metric.Status == "active"
 	}
+	cm.availableMetricsmu.Lock()
 	cm.availableMetrics = availableMetrics
+	cm.availableMetricsmu.Unlock()
 }
 
 // countNewTags returns a count of new tags which do not exist in the current list of tags

--- a/util.go
+++ b/util.go
@@ -51,57 +51,61 @@ func (m *CirconusMetrics) snapshot() (c map[string]uint64, g map[string]string, 
 }
 
 func (m *CirconusMetrics) snapCounters() map[string]uint64 {
+	m.cm.Lock()
+	defer m.cm.Unlock()
+	m.cfm.Lock()
+	defer m.cfm.Unlock()
+
 	c := make(map[string]uint64, len(m.counters)+len(m.counterFuncs))
 
-	m.cm.Lock()
 	for n, v := range m.counters {
 		c[n] = v
 	}
 	if m.resetCounters && len(c) > 0 {
 		m.counters = make(map[string]uint64)
 	}
-	m.cm.Unlock()
 
-	m.cfm.Lock()
 	for n, f := range m.counterFuncs {
 		c[n] = f()
 	}
 	if m.resetCounters && len(c) > 0 {
 		m.counterFuncs = make(map[string]func() uint64)
 	}
-	m.cfm.Unlock()
 
 	return c
 }
 
 func (m *CirconusMetrics) snapGauges() map[string]string {
+	m.gm.Lock()
+	defer m.gm.Unlock()
+	m.gfm.Lock()
+	defer m.gfm.Unlock()
+
 	g := make(map[string]string, len(m.gauges)+len(m.gaugeFuncs))
 
-	m.gm.Lock()
 	for n, v := range m.gauges {
 		g[n] = v
 	}
 	if m.resetGauges && len(g) > 0 {
 		m.gauges = make(map[string]string)
 	}
-	m.gm.Unlock()
 
-	m.gfm.Lock()
 	for n, f := range m.gaugeFuncs {
 		g[n] = m.gaugeValString(f())
 	}
 	if m.resetGauges && len(g) > 0 {
 		m.gaugeFuncs = make(map[string]func() int64)
 	}
-	m.gfm.Unlock()
 
 	return g
 }
 
 func (m *CirconusMetrics) snapHistograms() map[string]*circonusllhist.Histogram {
+	m.hm.Lock()
+	defer m.hm.Unlock()
+
 	h := make(map[string]*circonusllhist.Histogram, len(m.histograms))
 
-	m.hm.Lock()
 	for n, hist := range m.histograms {
 		hist.rw.Lock()
 		h[n] = hist.hist.CopyAndReset()
@@ -110,31 +114,31 @@ func (m *CirconusMetrics) snapHistograms() map[string]*circonusllhist.Histogram 
 	if m.resetHistograms && len(h) > 0 {
 		m.histograms = make(map[string]*Histogram)
 	}
-	m.hm.Unlock()
 
 	return h
 }
 
 func (m *CirconusMetrics) snapText() map[string]string {
+	m.tm.Lock()
+	defer m.tm.Unlock()
+	m.tfm.Lock()
+	defer m.tfm.Unlock()
+
 	t := make(map[string]string, len(m.text)+len(m.textFuncs))
 
-	m.tm.Lock()
 	for n, v := range m.text {
 		t[n] = v
 	}
 	if m.resetText && len(t) > 0 {
 		m.text = make(map[string]string)
 	}
-	m.tm.Unlock()
 
-	m.tfm.Lock()
 	for n, f := range m.textFuncs {
 		t[n] = f()
 	}
 	if m.resetText && len(t) > 0 {
 		m.textFuncs = make(map[string]func() string)
 	}
-	m.tfm.Unlock()
 
 	return t
 }


### PR DESCRIPTION
Add mutex locks to address two race conditions (checkmgr.initialized and api.useExponentialBackoff) from issue #42.