### PR TITLE
Retry broker connection tests and expose readiness state

### DIFF
--- a/checkmgr/broker_test.go
+++ b/checkmgr/broker_test.go
@@ -8,9 +8,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -327,6 +329,7 @@ func TestSelectBroker(t *testing.T) {
 
 func TestIsValidBroker(t *testing.T) {
 	cm := &CheckManager{
+		Log:                   log.New(os.Stderr, "", log.LstdFlags),
 		checkType:             "httptrap",
 		brokerMaxResponseTime: time.Duration(time.Millisecond * 50),
 	}
@@ -366,6 +369,7 @@ func TestIsValidBroker(t *testing.T) {
 
 	t.Log("unable to connect, broker.ExternalPort")
 	{
+		broker.Name = "test"
 		broker.Details[0].Modules = []string{"httptrap"}
 		broker.Details[0].Status = "active"
 		if cm.isValidBroker(&broker) {
@@ -375,6 +379,7 @@ func TestIsValidBroker(t *testing.T) {
 
 	t.Log("unable to connect, broker.Port")
 	{
+		broker.Name = "test"
 		broker.Details[0].ExternalPort = 0
 		broker.Details[0].Modules = []string{"httptrap"}
 		broker.Details[0].Status = "active"
@@ -385,6 +390,7 @@ func TestIsValidBroker(t *testing.T) {
 
 	t.Log("unable to connect, default port")
 	{
+		broker.Name = "test"
 		broker.Details[0].ExternalPort = 0
 		broker.Details[0].Port = &[]uint16{0}[0]
 		broker.Details[0].Modules = []string{"httptrap"}

--- a/circonus-gometrics.go
+++ b/circonus-gometrics.go
@@ -126,7 +126,7 @@ func New(cfg *Config) (*CirconusMetrics, error) {
 		cm.Debug = cfg.Debug
 		cm.Log = cfg.Log
 
-		if cm.Debug && cfg.Log == nil {
+		if cm.Debug && cm.Log == nil {
 			cm.Log = log.New(os.Stderr, "", log.LstdFlags)
 		}
 		if cm.Log == nil {
@@ -217,6 +217,11 @@ func New(cfg *Config) (*CirconusMetrics, error) {
 // Start deprecated NOP, automatic flush is started in New if flush interval > 0.
 func (m *CirconusMetrics) Start() {
 	return
+}
+
+// Ready returns true or false indicating if the check is ready to accept metrics
+func (m *CirconusMetrics) Ready() bool {
+	return m.check.IsReady()
 }
 
 // Flush metrics kicks off the process of sending metrics to Circonus


### PR DESCRIPTION
Retry broker connection tests five times.
Add a `Ready()` function for determining if CGM has fully initialized.