### PR TITLE
Update graph tests add CA Cert for API

### DIFF
--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -32,6 +32,7 @@ func main() {
     cfg.CheckManager.API.TokenKey = ""
     cfg.CheckManager.API.TokenApp = "circonus-gometrics"
     cfg.CheckManager.API.TokenURL = "https://api.circonus.com/v2"
+    cfg.CheckManager.API.CACert = nil
 
     // Check
     _, an := path.Split(os.Args[0])
@@ -72,6 +73,7 @@ func main() {
 | `cfg.CheckManager.API.TokenKey` | "" | [Circonus API Token key](https://login.circonus.com/user/tokens) |
 | `cfg.CheckManager.API.TokenApp` | "circonus-gometrics" | App associated with API token |
 | `cfg.CheckManager.API.URL` | "https://api.circonus.com/v2" | Circonus API URL |
+| `cfg.CheckManager.API.CACert` | nil | [*x509.CertPool](https://golang.org/pkg/crypto/x509/#CertPool) with CA Cert to validate API endpoint using internal CA or self-signed certificates |
 |Check||
 | `cfg.CheckManager.Check.ID` | "" | Check ID of previously created check. (*Note: **check id** not **check bundle id**.*) |
 | `cfg.CheckManager.Check.SubmissionURL` | "" | Submission URL of previously created check. |

--- a/api/graph.go
+++ b/api/graph.go
@@ -76,6 +76,7 @@ type GraphGuide struct {
 type GraphMetricCluster struct {
 	AggregateFunc string  `json:"aggregate_function,omitempty"` // string
 	Axis          string  `json:"axis,omitempty"`               // string
+	Color         *string `json:"color,omitempty"`              // string
 	DataFormula   *string `json:"data_formula"`                 // string or null
 	Hidden        bool    `json:"hidden"`                       // boolean
 	LegendFormula *string `json:"legend_formula"`               // string or null

--- a/api/graph_test.go
+++ b/api/graph_test.go
@@ -34,7 +34,7 @@ var (
 			GraphDatapoint{
 				Axis:        "l",
 				CheckID:     1234,
-				Color:       "#ff0000",
+				Color:       &[]string{"#ff0000"}[0],
 				DataFormula: &testFormula2,
 				Derive:      "gauge",
 				Hidden:      false,
@@ -45,7 +45,7 @@ var (
 			GraphDatapoint{
 				Axis:        "l",
 				CheckID:     2345,
-				Color:       "#00ff00",
+				Color:       &[]string{"#00ff00"}[0],
 				DataFormula: &testFormula2,
 				Derive:      "gauge",
 				Hidden:      false,
@@ -55,10 +55,10 @@ var (
 			},
 		},
 		Description: "Time to first byte verses time to whole thing",
-		LineStyle:   "interpolated",
-		LogLeftY:    10,
+		LineStyle:   &[]string{"interpolated"}[0],
+		LogLeftY:    &[]int{10}[0],
 		Notes:       &[]string{"This graph shows just the main webserver"}[0],
-		Style:       "line",
+		Style:       &[]string{"line"}[0],
 		Tags:        []string{"datacenter:primary"},
 		Title:       "Slow Webserver",
 	}


### PR DESCRIPTION
1. Update graph tests to match changes to the structure elements.
1. Add CACert option to API to facilitate using an API endpoint set up with an internal CA or self-signed certificates.