### PR TITLE
Add testing functions for counter/gauge/histogram

### DIFF
--- a/counter.go
+++ b/counter.go
@@ -4,6 +4,8 @@
 
 package circonusgometrics
 
+import "fmt"
+
 // A Counter is a monotonically increasing unsigned integer.
 //
 // Use a counter to derive rates (e.g., record total number of requests, derive
@@ -38,6 +40,19 @@ func (m *CirconusMetrics) RemoveCounter(metric string) {
 	m.cm.Lock()
 	defer m.cm.Unlock()
 	delete(m.counters, metric)
+}
+
+// GetCounterTest returns the current value for a counter. (note: it is a function specifically for "testing", disable automatic submission during testing.)
+func (m *CirconusMetrics) GetCounterTest(metric string) (uint64, error) {
+	m.cm.Lock()
+	defer m.cm.Unlock()
+
+	if val, ok := m.counters[metric]; ok {
+		return val, nil
+	}
+
+	return 0, fmt.Errorf("Counter metric '%s' not found", metric)
+
 }
 
 // SetCounterFunc set counter to a function [called at flush interval]

--- a/counter_test.go
+++ b/counter_test.go
@@ -36,6 +36,28 @@ func TestSet(t *testing.T) {
 	}
 }
 
+func TestGetCounterTest(t *testing.T) {
+	t.Log("Testing counter.GetCounterTest")
+
+	cm := &CirconusMetrics{counters: make(map[string]uint64)}
+
+	cm.Set("foo", 10)
+
+	val, err := cm.GetCounterTest("foo")
+	if err != nil {
+		t.Errorf("Expected no error %v", err)
+	}
+	if val != 10 {
+		t.Errorf("Expected 10 got %v", val)
+	}
+
+	_, err = cm.GetCounterTest("bar")
+	if err == nil {
+		t.Error("Expected error")
+	}
+
+}
+
 func TestIncrement(t *testing.T) {
 	t.Log("Testing counter.Increment")
 

--- a/gauge.go
+++ b/gauge.go
@@ -32,6 +32,18 @@ func (m *CirconusMetrics) RemoveGauge(metric string) {
 	delete(m.gauges, metric)
 }
 
+// GetGaugeTest returns the current value for a gauge. (note: it is a function specifically for "testing", disable automatic submission during testing.)
+func (m *CirconusMetrics) GetGaugeTest(metric string) (string, error) {
+	m.gm.Lock()
+	defer m.gm.Unlock()
+
+	if val, ok := m.gauges[metric]; ok {
+		return val, nil
+	}
+
+	return "", fmt.Errorf("Gauge metric '%s' not found", metric)
+}
+
 // SetGaugeFunc sets a gauge to a function [called at flush interval]
 func (m *CirconusMetrics) SetGaugeFunc(metric string, fn func() int64) {
 	m.gfm.Lock()

--- a/gauge_test.go
+++ b/gauge_test.go
@@ -207,6 +207,28 @@ func TestSetGauge(t *testing.T) {
 	}
 }
 
+func TestGetGaugeTest(t *testing.T) {
+	t.Log("Testing gauge.GetGaugeTest")
+
+	cm := &CirconusMetrics{gauges: make(map[string]string)}
+
+	cm.SetGauge("foo", 10)
+
+	val, err := cm.GetGaugeTest("foo")
+	if err != nil {
+		t.Errorf("Expected no error %v", err)
+	}
+	if val != "10" {
+		t.Errorf("Expected '10' got '%v'", val)
+	}
+
+	_, err = cm.GetGaugeTest("bar")
+	if err == nil {
+		t.Error("Expected error")
+	}
+
+}
+
 func TestRemoveGauge(t *testing.T) {
 	t.Log("Testing gauge.RemoveGauge")
 

--- a/histogram.go
+++ b/histogram.go
@@ -5,6 +5,7 @@
 package circonusgometrics
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/circonus-labs/circonusllhist"
@@ -36,6 +37,18 @@ func (m *CirconusMetrics) SetHistogramValue(metric string, val float64) {
 	hist.hist.RecordValue(val)
 	hist.rw.Unlock()
 	m.hm.Unlock()
+}
+
+// GetHistogramTest returns the current value for a gauge. (note: it is a function specifically for "testing", disable automatic submission during testing.)
+func (m *CirconusMetrics) GetHistogramTest(metric string) ([]string, error) {
+	m.hm.Lock()
+	defer m.hm.Unlock()
+
+	if hist, ok := m.histograms[metric]; ok {
+		return hist.hist.DecStrings(), nil
+	}
+
+	return []string{""}, fmt.Errorf("Histogram metric '%s' not found", metric)
 }
 
 // RemoveHistogram removes a histogram

--- a/histogram_test.go
+++ b/histogram_test.go
@@ -90,6 +90,32 @@ func TestSetHistogramValue(t *testing.T) {
 	}
 }
 
+func TestGetHistogramTest(t *testing.T) {
+	t.Log("Testing histogram.GetHistogramTest")
+
+	cm := &CirconusMetrics{histograms: make(map[string]*Histogram)}
+
+	cm.SetHistogramValue("foo", 10)
+	expected := "H[1.0e+01]=1"
+
+	val, err := cm.GetHistogramTest("foo")
+	if err != nil {
+		t.Errorf("Expected no error %v", err)
+	}
+	if len(val) == 0 {
+		t.Error("Expected 1 value, got 0 values")
+	}
+	if val[0] != expected {
+		t.Errorf("Expected '%s' got '%v'", expected, val[0])
+	}
+
+	_, err = cm.GetHistogramTest("bar")
+	if err == nil {
+		t.Error("Expected error")
+	}
+
+}
+
 func TestRemoveHistogram(t *testing.T) {
 	t.Log("Testing histogram.RemoveHistogram")
 


### PR DESCRIPTION
Add functions **specifically** for testing (should **not** be used in production code) to avoid having to mock a broker to receive submissions. Caveat: prevent automatic submissions; metrics will be reset after submission. set interval to zero and provide a bogus submission url to put cgm into _manual submission mode_ for testing set/get of metrics.