### PR TITLE
Pin variables to their iteration to prevent reuse.

### DIFF
--- a/checkmgr/broker.go
+++ b/checkmgr/broker.go
@@ -104,6 +104,7 @@ func (cm *CheckManager) selectBroker() (*api.Broker, error) {
 	haveEnterprise := false
 
 	for _, broker := range *brokerList {
+		broker := broker
 		if cm.isValidBroker(&broker) {
 			validBrokers[broker.CID] = broker
 			if broker.Type == "enterprise" {
@@ -166,6 +167,7 @@ func (cm *CheckManager) isValidBroker(broker *api.Broker) bool {
 	var brokerPort string
 	valid := false
 	for _, detail := range broker.Details {
+		detail := detail
 
 		// broker must be active
 		if detail.Status != statusActive {


### PR DESCRIPTION
This is required when passing references.  This class of bug can be rather insidious to detect.

H/T to https://github.com/kyoh86/scopelint for pointing this out.

```
checkmgr/broker.go:107:24: Using a reference for the variable on range scope "broker"
checkmgr/broker.go:179:49: Using a reference for the variable on range scope "detail"
```