### PR TITLE
Update to use latest dependencies

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -5,7 +5,7 @@
   branch = "master"
   name = "github.com/circonus-labs/circonusllhist"
   packages = ["."]
-  revision = "1e65893c445875524c5610f2a58aef24e30ef98a"
+  revision = "5eb751da55c6d3091faf3861ec5062ae91fee9d0"
 
 [[projects]]
   branch = "master"
@@ -17,7 +17,7 @@
   branch = "master"
   name = "github.com/hashicorp/go-retryablehttp"
   packages = ["."]
-  revision = "794af36148bf63c118d6db80eb902a136b907e71"
+  revision = "e651d75abec6fbd4f2c09508f72ae7af8a8b7171"
 
 [[projects]]
   name = "github.com/pkg/errors"

--- a/api/api.go
+++ b/api/api.go
@@ -279,7 +279,7 @@ func (a *API) apiCall(reqMethod string, reqPath string, data []byte) ([]byte, er
 
 	// keep last HTTP error in the event of retry failure
 	var lastHTTPError error
-	retryPolicy := func(resp *http.Response, err error) (bool, error) {
+	retryPolicy := func(_ context.Context, resp *http.Response, err error) (bool, error) {
 		if err != nil {
 			lastHTTPError = err
 			return true, err

--- a/api/api.go
+++ b/api/api.go
@@ -6,6 +6,7 @@ package api
 
 import (
 	"bytes"
+	"context"
 	crand "crypto/rand"
 	"crypto/tls"
 	"crypto/x509"

--- a/submit.go
+++ b/submit.go
@@ -6,6 +6,7 @@ package circonusgometrics
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -71,7 +72,7 @@ func (m *CirconusMetrics) trapCall(payload []byte) (int, error) {
 
 	// keep last HTTP error in the event of retry failure
 	var lastHTTPError error
-	retryPolicy := func(resp *http.Response, err error) (bool, error) {
+	retryPolicy := func(_ context.Context, resp *http.Response, err error) (bool, error) {
 		if err != nil {
 			lastHTTPError = err
 			return true, errors.Wrap(err, "retry policy")


### PR DESCRIPTION
This makes the package go gettable again.

If `dep` is used, it is probably a good idea to check in the `vendor` directory. That said, it is your choice after all.