### PR TITLE
v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
-# v2.1.3
+# v2.2.0
 
+* fix: do not reset counter|gauge|text funcs after each snapshot (only on explicit call to Reset)
+* upd: dashboards - optional widget attributes - which are structs - should be pointers for correct omission in json sent to api
+* fix: dashboards - remove `omitempty` from required attributes
+* fix: graphs - remove `omitempty` from required attributes
+* fix: worksheets - correct attribute name, remove `omitempty` from required attributes
 * fix: handle case where a broker has no external host or ip set
 
 # v2.1.2

--- a/api/dashboard.go
+++ b/api/dashboard.go
@@ -24,24 +24,24 @@ type DashboardGridLayout struct {
 
 // DashboardAccessConfig defines access config
 type DashboardAccessConfig struct {
-	BlackDash           bool   `json:"black_dash,omitempty"`
-	Enabled             bool   `json:"enabled,omitempty"`
-	Fullscreen          bool   `json:"fullscreen,omitempty"`
-	FullscreenHideTitle bool   `json:"fullscreen_hide_title,omitempty"`
-	Nickname            string `json:"nickname,omitempty"`
-	ScaleText           bool   `json:"scale_text,omitempty"`
-	SharedID            string `json:"shared_id,omitempty"`
-	TextSize            uint   `json:"text_size,omitempty"`
+	BlackDash           bool   `json:"black_dash"`
+	Enabled             bool   `json:"enabled"`
+	Fullscreen          bool   `json:"fullscreen"`
+	FullscreenHideTitle bool   `json:"fullscreen_hide_title"`
+	Nickname            string `json:"nickname"`
+	ScaleText           bool   `json:"scale_text"`
+	SharedID            string `json:"shared_id"`
+	TextSize            uint   `json:"text_size"`
 }
 
 // DashboardOptions defines options
 type DashboardOptions struct {
-	AccessConfigs       []DashboardAccessConfig `json:"access_configs,omitempty"`
-	FullscreenHideTitle bool                    `json:"fullscreen_hide_title,omitempty"`
-	HideGrid            bool                    `json:"hide_grid,omitempty"`
-	Linkages            [][]string              `json:"linkages,omitempty"`
-	ScaleText           bool                    `json:"scale_text,omitempty"`
-	TextSize            uint                    `json:"text_size,omitempty"`
+	AccessConfigs       []DashboardAccessConfig `json:"access_configs"`
+	FullscreenHideTitle bool                    `json:"fullscreen_hide_title"`
+	HideGrid            bool                    `json:"hide_grid"`
+	Linkages            [][]string              `json:"linkages"`
+	ScaleText           bool                    `json:"scale_text"`
+	TextSize            uint                    `json:"text_size"`
 }
 
 // ChartTextWidgetDatapoint defines datapoints for charts
@@ -116,67 +116,68 @@ type StatusWidgetHostStatusSettings struct {
 }
 
 // DashboardWidgetSettings defines settings specific to widget
+// Note: optional attributes which are structs need to be pointers so they will be omitted
 type DashboardWidgetSettings struct {
-	AccountID           string                          `json:"account_id,omitempty"`            // alerts, clusters, gauges, graphs, lists, status
-	Acknowledged        string                          `json:"acknowledged,omitempty"`          // alerts
-	AgentStatusSettings StatusWidgetAgentStatusSettings `json:"agent_status_settings,omitempty"` // status
-	Algorithm           string                          `json:"algorithm,omitempty"`             // clusters
-	Autoformat          bool                            `json:"autoformat,omitempty"`            // text
-	BodyFormat          string                          `json:"body_format,omitempty"`           // text
-	ChartType           string                          `json:"chart_type,omitempty"`            // charts
-	CheckUUID           string                          `json:"check_uuid,omitempty"`            // gauges
-	Cleared             string                          `json:"cleared,omitempty"`               // alerts
-	ClusterID           uint                            `json:"cluster_id,omitempty"`            // clusters
-	ClusterName         string                          `json:"cluster_name,omitempty"`          // clusters
-	ContactGroups       []uint                          `json:"contact_groups,omitempty"`        // alerts
-	ContentType         string                          `json:"content_type,omitempty"`          // status
-	Datapoints          []ChartTextWidgetDatapoint      `json:"datapoints,omitempty"`            // charts, text
-	DateWindow          string                          `json:"date_window,omitempty"`           // graphs
-	Definition          ChartWidgtDefinition            `json:"definition,omitempty"`            // charts
-	Dependents          string                          `json:"dependents,omitempty"`            // alerts
-	DisableAutoformat   bool                            `json:"disable_autoformat,omitempty"`    // gauges
-	Display             string                          `json:"display,omitempty"`               // alerts
-	Format              string                          `json:"format,omitempty"`                // forecasts
-	Formula             string                          `json:"formula,omitempty"`               // gauges
-	GraphUUID           string                          `json:"graph_id,omitempty"`              // graphs
-	HideXAxis           bool                            `json:"hide_xaxis,omitempty"`            // graphs
-	HideYAxis           bool                            `json:"hide_yaxis,omitempty"`            // graphs
-	HostStatusSettings  StatusWidgetHostStatusSettings  `json:"host_status_settings,omitempty"`  // status
-	KeyInline           bool                            `json:"key_inline,omitempty"`            // graphs
-	KeyLoc              string                          `json:"key_loc,omitempty"`               // graphs
-	KeySize             uint                            `json:"key_size,omitempty"`              // graphs
-	KeyWrap             bool                            `json:"key_wrap,omitempty"`              // graphs
-	Label               string                          `json:"label,omitempty"`                 // graphs
-	Layout              string                          `json:"layout,omitempty"`                // clusters
-	Limit               uint                            `json:"limit,omitempty"`                 // lists
-	Maintenance         string                          `json:"maintenance,omitempty"`           // alerts
-	Markup              string                          `json:"markup,omitempty"`                // html
-	MetricDisplayName   string                          `json:"metric_display_name,omitempty"`   // gauges
-	MetricName          string                          `json:"metric_name,omitempty"`           // gauges
-	MinAge              string                          `json:"min_age,omitempty"`               // alerts
-	OffHours            []uint                          `json:"off_hours,omitempty"`             // alerts
-	OverlaySetID        string                          `json:"overlay_set_id,omitempty"`        // graphs
-	Period              uint                            `json:"period,omitempty"`                // gauges, text, graphs
-	RangeHigh           int                             `json:"range_high,omitempty"`            // gauges
-	RangeLow            int                             `json:"range_low,omitempty"`             // gauges
-	Realtime            bool                            `json:"realtime,omitempty"`              // graphs
-	ResourceLimit       string                          `json:"resource_limit,omitempty"`        // forecasts
-	ResourceUsage       string                          `json:"resource_usage,omitempty"`        // forecasts
-	Search              string                          `json:"search,omitempty"`                // alerts, lists
-	Severity            string                          `json:"severity,omitempty"`              // alerts
-	ShowFlags           bool                            `json:"show_flags,omitempty"`            // graphs
-	Size                string                          `json:"size,omitempty"`                  // clusters
-	TagFilterSet        []string                        `json:"tag_filter_set,omitempty"`        // alerts
-	Threshold           float32                         `json:"threshold,omitempty"`             // clusters
-	Thresholds          ForecastGaugeWidgetThresholds   `json:"thresholds,omitempty"`            // forecasts, gauges
-	TimeWindow          string                          `json:"time_window,omitempty"`           // alerts
-	Title               string                          `json:"title,omitempty"`                 // alerts, charts, forecasts, gauges, html
-	TitleFormat         string                          `json:"title_format,omitempty"`          // text
-	Trend               string                          `json:"trend,omitempty"`                 // forecasts
-	Type                string                          `json:"type,omitempty"`                  // gauges, lists
-	UseDefault          bool                            `json:"use_default,omitempty"`           // text
-	ValueType           string                          `json:"value_type,omitempty"`            // gauges, text
-	WeekDays            []string                        `json:"weekdays,omitempty"`              // alerts
+	AccountID           string                           `json:"account_id,omitempty"`            // alerts, clusters, gauges, graphs, lists, status
+	Acknowledged        string                           `json:"acknowledged,omitempty"`          // alerts
+	AgentStatusSettings *StatusWidgetAgentStatusSettings `json:"agent_status_settings,omitempty"` // status
+	Algorithm           string                           `json:"algorithm,omitempty"`             // clusters
+	Autoformat          bool                             `json:"autoformat,omitempty"`            // text
+	BodyFormat          string                           `json:"body_format,omitempty"`           // text
+	ChartType           string                           `json:"chart_type,omitempty"`            // charts
+	CheckUUID           string                           `json:"check_uuid,omitempty"`            // gauges
+	Cleared             string                           `json:"cleared,omitempty"`               // alerts
+	ClusterID           uint                             `json:"cluster_id,omitempty"`            // clusters
+	ClusterName         string                           `json:"cluster_name,omitempty"`          // clusters
+	ContactGroups       []uint                           `json:"contact_groups,omitempty"`        // alerts
+	ContentType         string                           `json:"content_type,omitempty"`          // status
+	Datapoints          []ChartTextWidgetDatapoint       `json:"datapoints,omitempty"`            // charts, text
+	DateWindow          string                           `json:"date_window,omitempty"`           // graphs
+	Definition          *ChartWidgtDefinition            `json:"definition,omitempty"`            // charts
+	Dependents          string                           `json:"dependents,omitempty"`            // alerts
+	DisableAutoformat   bool                             `json:"disable_autoformat,omitempty"`    // gauges
+	Display             string                           `json:"display,omitempty"`               // alerts
+	Format              string                           `json:"format,omitempty"`                // forecasts
+	Formula             string                           `json:"formula,omitempty"`               // gauges
+	GraphUUID           string                           `json:"graph_id,omitempty"`              // graphs
+	HideXAxis           bool                             `json:"hide_xaxis,omitempty"`            // graphs
+	HideYAxis           bool                             `json:"hide_yaxis,omitempty"`            // graphs
+	HostStatusSettings  *StatusWidgetHostStatusSettings  `json:"host_status_settings,omitempty"`  // status
+	KeyInline           bool                             `json:"key_inline,omitempty"`            // graphs
+	KeyLoc              string                           `json:"key_loc,omitempty"`               // graphs
+	KeySize             uint                             `json:"key_size,omitempty"`              // graphs
+	KeyWrap             bool                             `json:"key_wrap,omitempty"`              // graphs
+	Label               string                           `json:"label,omitempty"`                 // graphs
+	Layout              string                           `json:"layout,omitempty"`                // clusters
+	Limit               uint                             `json:"limit,omitempty"`                 // lists
+	Maintenance         string                           `json:"maintenance,omitempty"`           // alerts
+	Markup              string                           `json:"markup,omitempty"`                // html
+	MetricDisplayName   string                           `json:"metric_display_name,omitempty"`   // gauges
+	MetricName          string                           `json:"metric_name,omitempty"`           // gauges
+	MinAge              string                           `json:"min_age,omitempty"`               // alerts
+	OffHours            []uint                           `json:"off_hours,omitempty"`             // alerts
+	OverlaySetID        string                           `json:"overlay_set_id,omitempty"`        // graphs
+	Period              uint                             `json:"period,omitempty"`                // gauges, text, graphs
+	RangeHigh           int                              `json:"range_high,omitempty"`            // gauges
+	RangeLow            int                              `json:"range_low,omitempty"`             // gauges
+	Realtime            bool                             `json:"realtime,omitempty"`              // graphs
+	ResourceLimit       string                           `json:"resource_limit,omitempty"`        // forecasts
+	ResourceUsage       string                           `json:"resource_usage,omitempty"`        // forecasts
+	Search              string                           `json:"search,omitempty"`                // alerts, lists
+	Severity            string                           `json:"severity,omitempty"`              // alerts
+	ShowFlags           bool                             `json:"show_flags,omitempty"`            // graphs
+	Size                string                           `json:"size,omitempty"`                  // clusters
+	TagFilterSet        []string                         `json:"tag_filter_set,omitempty"`        // alerts
+	Threshold           float32                          `json:"threshold,omitempty"`             // clusters
+	Thresholds          *ForecastGaugeWidgetThresholds   `json:"thresholds,omitempty"`            // forecasts, gauges
+	TimeWindow          string                           `json:"time_window,omitempty"`           // alerts
+	Title               string                           `json:"title,omitempty"`                 // alerts, charts, forecasts, gauges, html
+	TitleFormat         string                           `json:"title_format,omitempty"`          // text
+	Trend               string                           `json:"trend,omitempty"`                 // forecasts
+	Type                string                           `json:"type,omitempty"`                  // gauges, lists
+	UseDefault          bool                             `json:"use_default,omitempty"`           // text
+	ValueType           string                           `json:"value_type,omitempty"`            // gauges, text
+	WeekDays            []string                         `json:"weekdays,omitempty"`              // alerts
 }
 
 // DashboardWidget defines widget

--- a/api/graph.go
+++ b/api/graph.go
@@ -37,13 +37,13 @@ type GraphAccessKey struct {
 
 // GraphComposite defines a composite
 type GraphComposite struct {
-	Axis          string  `json:"axis,omitempty"`           // string
-	Color         string  `json:"color,omitempty"`          // string
-	DataFormula   *string `json:"data_formula,omitempty"`   // string or null
-	Hidden        bool    `json:"hidden,omitempty"`         // boolean
-	LegendFormula *string `json:"legend_formula,omitempty"` // string or null
-	Name          string  `json:"name,omitempty"`           // string
-	Stack         *uint   `json:"stack,omitempty"`          // uint or null
+	Axis          string  `json:"axis"`           // string
+	Color         string  `json:"color"`          // string
+	DataFormula   *string `json:"data_formula"`   // string or null
+	Hidden        bool    `json:"hidden"`         // boolean
+	LegendFormula *string `json:"legend_formula"` // string or null
+	Name          string  `json:"name"`           // string
+	Stack         *uint   `json:"stack"`          // uint or null
 }
 
 // GraphDatapoint defines a datapoint

--- a/api/graph.go
+++ b/api/graph.go
@@ -65,11 +65,11 @@ type GraphDatapoint struct {
 
 // GraphGuide defines a guide
 type GraphGuide struct {
-	Color         string  `json:"color,omitempty"`          // string
-	DataFormula   *string `json:"data_formula,omitempty"`   // string or null
-	Hidden        bool    `json:"hidden,omitempty"`         // boolean
-	LegendFormula *string `json:"legend_formula,omitempty"` // string or null
-	Name          string  `json:"name,omitempty"`           // string
+	Color         string  `json:"color"`          // string
+	DataFormula   *string `json:"data_formula"`   // string or null
+	Hidden        bool    `json:"hidden"`         // boolean
+	LegendFormula *string `json:"legend_formula"` // string or null
+	Name          string  `json:"name"`           // string
 }
 
 // GraphMetricCluster defines a metric cluster

--- a/api/worksheet.go
+++ b/api/worksheet.go
@@ -30,14 +30,14 @@ type WorksheetSmartQuery struct {
 
 // Worksheet defines a worksheet. See https://login.circonus.com/resources/api/calls/worksheet for more information.
 type Worksheet struct {
-	CID          string                `json:"_cid"`          // string
-	Description  *string               `json:"description"`   // string or null
-	Favorite     bool                  `json:"favorite"`      // boolean
-	Graphs       []WorksheetGraph      `json:"graphs"`        // [] len >= 0
-	Notes        *string               `json:"notes"`         // string or null
-	SmartQueries []WorksheetSmartQuery `json:"smart_queries"` // [] len >= 0
-	Tags         []string              `json:"tags"`          // [] len >= 0
-	Title        string                `json:"title"`         // string
+	CID          string                `json:"_cid,omitempty"` // string
+	Description  *string               `json:"description"`    // string or null
+	Favorite     bool                  `json:"favorite"`       // boolean
+	Graphs       []WorksheetGraph      `json:"graphs"`         // [] len >= 0
+	Notes        *string               `json:"notes"`          // string or null
+	SmartQueries []WorksheetSmartQuery `json:"smart_queries"`  // [] len >= 0
+	Tags         []string              `json:"tags"`           // [] len >= 0
+	Title        string                `json:"title"`          // string
 }
 
 // NewWorksheet returns a new Worksheet (with defaults, if applicable)

--- a/api/worksheet.go
+++ b/api/worksheet.go
@@ -30,14 +30,14 @@ type WorksheetSmartQuery struct {
 
 // Worksheet defines a worksheet. See https://login.circonus.com/resources/api/calls/worksheet for more information.
 type Worksheet struct {
-	CID          string                `json:"_cid,omitempty"`          // string
-	Description  *string               `json:"description"`             // string or null
-	Favorite     bool                  `json:"favorite"`                // boolean
-	Graphs       []WorksheetGraph      `json:"worksheets,omitempty"`    // [] len >= 0
-	Notes        *string               `json:"notes"`                   // string or null
-	SmartQueries []WorksheetSmartQuery `json:"smart_queries,omitempty"` // [] len >= 0
-	Tags         []string              `json:"tags"`                    // [] len >= 0
-	Title        string                `json:"title"`                   // string
+	CID          string                `json:"_cid"`          // string
+	Description  *string               `json:"description"`   // string or null
+	Favorite     bool                  `json:"favorite"`      // boolean
+	Graphs       []WorksheetGraph      `json:"graphs"`        // [] len >= 0
+	Notes        *string               `json:"notes"`         // string or null
+	SmartQueries []WorksheetSmartQuery `json:"smart_queries"` // [] len >= 0
+	Tags         []string              `json:"tags"`          // [] len >= 0
+	Title        string                `json:"title"`         // string
 }
 
 // NewWorksheet returns a new Worksheet (with defaults, if applicable)

--- a/util.go
+++ b/util.go
@@ -68,9 +68,6 @@ func (m *CirconusMetrics) snapCounters() map[string]uint64 {
 	for n, f := range m.counterFuncs {
 		c[n] = f()
 	}
-	if m.resetCounters && len(c) > 0 {
-		m.counterFuncs = make(map[string]func() uint64)
-	}
 
 	return c
 }
@@ -92,9 +89,6 @@ func (m *CirconusMetrics) snapGauges() map[string]interface{} {
 
 	for n, f := range m.gaugeFuncs {
 		g[n] = f()
-	}
-	if m.resetGauges && len(g) > 0 {
-		m.gaugeFuncs = make(map[string]func() int64)
 	}
 
 	return g
@@ -135,9 +129,6 @@ func (m *CirconusMetrics) snapText() map[string]string {
 
 	for n, f := range m.textFuncs {
 		t[n] = f()
-	}
-	if m.resetText && len(t) > 0 {
-		m.textFuncs = make(map[string]func() string)
 	}
 
 	return t


### PR DESCRIPTION
* fix: do not reset counter|gauge|text funcs after each snapshot (only on explicit call to Reset)
* upd: dashboards - optional widget attributes - which are structs - should be pointers for correct omission in json sent to api
* fix: dashboards - remove `omitempty` from required attributes
* fix: graphs - remove `omitempty` from required attributes
* fix: worksheets - correct attribute name, remove `omitempty` from required attributes
* fix: handle case where a broker has no external host or ip set
