### PR TITLE
v2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v2.2.1
+
+* fix: if submission url host is 'api.circonus.com' do not use private CA in TLSConfig
+
 # v2.2.0
 
 * fix: do not reset counter|gauge|text funcs after each snapshot (only on explicit call to Reset)

--- a/checkmgr/checkmgr.go
+++ b/checkmgr/checkmgr.go
@@ -458,8 +458,10 @@ func (cm *CheckManager) GetSubmissionURL() (*Trap, error) {
 			return trap, nil
 		}
 
-		// api.circonus.com uses a public certificate
-		if u.Hostname() == "api.circonus.com" {
+		// api.circonus.com uses a public CA signed certificate
+		// trap.noit.circonus.net uses Circonus CA private certificate
+		// enterprise brokers use private CA certificate
+		if trap.URL.Hostname() == "api.circonus.com" {
 			return trap, nil
 		}
 

--- a/checkmgr/checkmgr.go
+++ b/checkmgr/checkmgr.go
@@ -458,6 +458,11 @@ func (cm *CheckManager) GetSubmissionURL() (*Trap, error) {
 			return trap, nil
 		}
 
+		// api.circonus.com uses a public certificate
+		if u.Hostname() == "api.circonus.com" {
+			return trap, nil
+		}
+
 		if cm.certPool == nil {
 			if err := cm.loadCACert(); err != nil {
 				return nil, errors.Wrap(err, "get submission url")


### PR DESCRIPTION
* fix: if submission url host is 'api.circonus.com' do not use private CA in TLSConfig