### PR TITLE
worksheets Order needs to be annotated as omitempty

### DIFF
--- a/api/worksheet.go
+++ b/api/worksheet.go
@@ -24,7 +24,7 @@ type WorksheetGraph struct {
 // WorksheetSmartQuery defines a query to include multiple worksheets
 type WorksheetSmartQuery struct {
 	Name  string   `json:"name"`
-	Order []string `json:"order"`
+	Order []string `json:"order,omitempty"`
 	Query string   `json:"query"`
 }
 


### PR DESCRIPTION
The `Order` attribute is not a required attribute for `WorksheetSmartQuery` when posting to the API endpoint.  It should be marked as `omitempty`.  If this attribute is going to be made required in the near future, a helper method `NewWorksheetSmartQuery()` should be created that populates the `Order` attribute with an empty string list.  In addition to https://github.com/terraform-providers/terraform-provider-circonus/pull/22, this is required to fix the `circonus_worksheet` resource in `terraform-provider-circonus `.