### PR TITLE
Add RecordDuration() support to circonus-gometrics

### DIFF
--- a/histogram_test.go
+++ b/histogram_test.go
@@ -5,8 +5,10 @@
 package circonusgometrics
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestTiming(t *testing.T) {
@@ -61,6 +63,57 @@ func TestRecordValue(t *testing.T) {
 	if val[0] != expectedVal {
 		t.Errorf("Expected '%s', found '%s'", expectedVal, val[0])
 	}
+}
+
+func TestRecordDuration(t *testing.T) {
+	t.Log("Testing histogram.RecordDuration")
+
+	tests := []struct {
+		metricName string
+		durs       []time.Duration
+		out        string
+	}{
+		{
+			metricName: "foo",
+			durs:       []time.Duration{1 * time.Second},
+			out:        "H[1.0e+00]=1",
+		},
+		{
+			metricName: "foo",
+			durs:       []time.Duration{1 * time.Millisecond},
+			out:        "H[1.0e-03]=1",
+		},
+	}
+
+	for n, test := range tests {
+		test := test
+		t.Run(fmt.Sprintf("%d", n), func(t *testing.T) {
+			cm := &CirconusMetrics{histograms: make(map[string]*Histogram)}
+
+			for _, dur := range test.durs {
+				cm.RecordDuration(test.metricName, dur)
+			}
+
+			hist, ok := cm.histograms[test.metricName]
+			if !ok {
+				t.Errorf("Expected to find %q", test.metricName)
+			}
+
+			if hist == nil {
+				t.Errorf("Expected *Histogram, found %v", hist)
+			}
+
+			val := hist.hist.DecStrings()
+			if len(val) != 1 {
+				t.Errorf("Expected 1, found '%v'", val)
+			}
+
+			if val[0] != test.out {
+				t.Errorf("Expected '%s', found '%s'", test.out, val[0])
+			}
+		})
+	}
+
 }
 
 func TestRecordCountForValue(t *testing.T) {


### PR DESCRIPTION
This is the preferred and normalized way to record `time.Duration`