### PR TITLE
Add RecordDuration() support to circonus-gometrics

### DIFF
--- a/histogram.go
+++ b/histogram.go
@@ -44,10 +44,16 @@ func (m *CirconusMetrics) RecordCountForValueWithTags(metric string, tags Tags, 
 	m.RecordCountForValue(MetricNameWithStreamTags(metric, tags), val, n)
 }
 
-// RecordDuration adds a time.Duration to a histogram (values normalized to
-// time.Second, but supports nanosecond granularity).
+// RecordDuration adds a time.Duration to a histogram metric (duration is
+// normalized to time.Second, but supports nanosecond granularity).
 func (m *CirconusMetrics) RecordDuration(metric string, val time.Duration) {
 	m.SetHistogramDuration(metric, val)
+}
+
+// RecordDurationWithTags adds a time.Duration to a histogram metric with tags
+// (duration is normalized to time.Second, but supports nanosecond granularity).
+func (m *CirconusMetrics) RecordDurationWithTags(metric string, tags Tags, val time.Duration) {
+	m.SetHistogramDuration(MetricNameWithStreamTags(metric, tags), val)
 }
 
 // RecordCountForValue adds count n for value to a histogram

--- a/histogram_test.go
+++ b/histogram_test.go
@@ -5,8 +5,10 @@
 package circonusgometrics
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestTiming(t *testing.T) {
@@ -123,6 +125,56 @@ func TestRecordValueWithTags(t *testing.T) {
 	expectedVal := "H[1.0e+00]=1"
 	if val[0] != expectedVal {
 		t.Errorf("Expected '%s', found '%s'", expectedVal, val[0])
+	}
+}
+
+func TestRecordDuration(t *testing.T) {
+	t.Log("Testing histogram.RecordDuration")
+
+	tests := []struct {
+		metricName string
+		durs       []time.Duration
+		out        string
+	}{
+		{
+			metricName: "foo",
+			durs:       []time.Duration{1 * time.Second},
+			out:        "H[1.0e+00]=1",
+		},
+		{
+			metricName: "foo",
+			durs:       []time.Duration{1 * time.Millisecond},
+			out:        "H[1.0e-03]=1",
+		},
+	}
+
+	for n, test := range tests {
+		test := test
+		t.Run(fmt.Sprintf("%d", n), func(t *testing.T) {
+			cm := &CirconusMetrics{histograms: make(map[string]*Histogram)}
+
+			for _, dur := range test.durs {
+				cm.RecordDuration(test.metricName, dur)
+			}
+
+			hist, ok := cm.histograms[test.metricName]
+			if !ok {
+				t.Errorf("Expected to find %q", test.metricName)
+			}
+
+			if hist == nil {
+				t.Errorf("Expected *Histogram, found %v", hist)
+			}
+
+			val := hist.hist.DecStrings()
+			if len(val) != 1 {
+				t.Errorf("Expected 1, found '%v'", val)
+			}
+
+			if val[0] != test.out {
+				t.Errorf("Expected '%s', found '%s'", test.out, val[0])
+			}
+		})
 	}
 }
 

--- a/histogram_test.go
+++ b/histogram_test.go
@@ -135,6 +135,7 @@ func TestRecordDuration(t *testing.T) {
 		metricName string
 		durs       []time.Duration
 		out        string
+		tags       Tags
 	}{
 		{
 			metricName: "foo",
@@ -146,6 +147,12 @@ func TestRecordDuration(t *testing.T) {
 			durs:       []time.Duration{1 * time.Millisecond},
 			out:        "H[1.0e-03]=1",
 		},
+		{
+			metricName: "foo",
+			durs:       []time.Duration{1 * time.Millisecond},
+			tags:       Tags{Tag{"unit", "ms"}},
+			out:        "H[1.0e-03]=1",
+		},
 	}
 
 	for n, test := range tests {
@@ -154,7 +161,11 @@ func TestRecordDuration(t *testing.T) {
 			cm := &CirconusMetrics{histograms: make(map[string]*Histogram)}
 
 			for _, dur := range test.durs {
-				cm.RecordDuration(test.metricName, dur)
+				if len(test.tags) > 0 {
+					cm.RecordDuration(test.metricName, dur)
+				} else {
+					cm.RecordDurationWithTags(test.metricName, test.tags, dur)
+				}
 			}
 
 			hist, ok := cm.histograms[test.metricName]


### PR DESCRIPTION
This is the preferred and normalized way to record `time.Duration`