### PR TITLE
v2.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v2.2.5
+
+* upd: switch from tracking master to versions for retryablehttp and circonusllhist now that both repositories are doing releases
+
 # v2.2.4
 
 * fix: worksheet.graphs is a required attribute. worksheet.smart_queries is an optional attribute.

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,22 +2,22 @@
 
 
 [[projects]]
-  branch = "master"
   name = "github.com/circonus-labs/circonusllhist"
   packages = ["."]
-  revision = "5eb751da55c6d3091faf3861ec5062ae91fee9d0"
+  revision = "15a405ff8a5115071928817fea151c3a420c5246"
+  version = "v0.1.2"
 
 [[projects]]
-  branch = "master"
   name = "github.com/hashicorp/go-cleanhttp"
   packages = ["."]
-  revision = "d5fe4b57a186c716b0e00b8c301cbd9b4182694d"
+  revision = "e8ab9daed8d1ddd2d3c4efba338fe2eeae2e4f18"
+  version = "v0.5.0"
 
 [[projects]]
-  branch = "master"
   name = "github.com/hashicorp/go-retryablehttp"
   packages = ["."]
-  revision = "e651d75abec6fbd4f2c09508f72ae7af8a8b7171"
+  revision = "4502c0ecdaf0b50d857611af23831260f99be6bf"
+  version = "v0.5.0"
 
 [[projects]]
   name = "github.com/pkg/errors"
@@ -34,6 +34,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "6db34ba31cd011426f28b5db0dbe259c4dc3787fb2074b2c06cb382385a90242"
+  inputs-digest = "0067a8daf91f9a5bdcfa288b6d4c35ec0264322414ccb60582d34eb579e46b85"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,32 +1,10 @@
-# Gopkg.toml example
-#
-# Refer to https://github.com/golang/dep/blob/master/docs/Gopkg.toml.md
-# for detailed Gopkg.toml documentation.
-#
-# required = ["github.com/user/thing/cmd/thing"]
-# ignored = ["github.com/user/project/pkgX", "bitbucket.org/user/project/pkgA/pkgY"]
-#
-# [[constraint]]
-#   name = "github.com/user/project"
-#   version = "1.0.0"
-#
-# [[constraint]]
-#   name = "github.com/user/project2"
-#   branch = "dev"
-#   source = "github.com/myfork/project2"
-#
-# [[override]]
-#  name = "github.com/x/y"
-#  version = "2.4.0"
-
-
 [[constraint]]
-  branch = "master"
   name = "github.com/circonus-labs/circonusllhist"
+  version = "0.1.2"
 
 [[constraint]]
-  branch = "master"
   name = "github.com/hashicorp/go-retryablehttp"
+  version = "0.5.0"
 
 [[constraint]]
   name = "github.com/pkg/errors"


### PR DESCRIPTION
* upd: switch from tracking master to versions for retryablehttp and circonusllhist now that both repositories are doing releases
