### PR TITLE
v2.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v2.2.6
+
+* fix: function signature for retryablehttp request log hook...
+
 # v2.2.5
 
 * upd: switch from tracking master to versions for retryablehttp and circonusllhist now that both repositories are doing releases

--- a/submit.go
+++ b/submit.go
@@ -141,7 +141,7 @@ func (m *CirconusMetrics) trapCall(payload []byte) (int, error) {
 	client.CheckRetry = retryPolicy
 
 	attempts := -1
-	client.RequestLogHook = func(logger *log.Logger, req *http.Request, retryNumber int) {
+	client.RequestLogHook = func(logger retryablehttp.Logger, req *http.Request, retryNumber int) {
 		attempts = retryNumber
 	}
 


### PR DESCRIPTION
* fix: func signature for retryablehttp.RequestLogHook

function signature still needed to be updated. passed first test, failed second...