### PR TITLE
v3.0.0-alpha.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# v3.0.0-alpha.5
+
+* add: allow any log package with a `Printf` to be used
+* upd: circonus-labs/go-apiclient v0.5.2 (for generic log support)
+* upd: ensure only `Printf` is used for logging
+* upd: migrate to errors package (`errors.Wrap` et al.)
+* upd: error and log messages, remove explicit log level classifications from logging messages
+* upd: OBSOLETE github.com/circonus-labs/v3/circonus-gometrics/api will be REMOVED --- USE **github.com/circonus-labs/go-apiclient**
+
 # v3.0.0-alpha.4
 
 * add: missing SetHistogramDurationWithTags
@@ -25,7 +34,7 @@
 * add: metric_filters support
 * upd: dependencies (circonusllhist v0.1.0)
 * upd: change histograms from type 'n' to type 'h' in submissions
-* upd: DEPRECATED github.com/circonus-labs/circonus-gometrics/api
+* upd: DEPRECATED github.com/circonus-labs/v3/circonus-gometrics/api
 * upd: switch to using github.com/circonus-labs/go-apiclient
 * upd: merge other metric tag functions into tags
 * add: helper methods for handling tags (for new stream tags syntax and old check_bundle.metrics.metric.tags)

--- a/api/README.md
+++ b/api/README.md
@@ -1,3 +1,5 @@
 # !!!!! DEPRECATED !!!!!
 
 Use [github.com/circonus-labs/go-apiclient](https://github.com/circonus-labs/go-apiclient)
+
+This will be **REMOVED** in an upcoming v3 point release.

--- a/checkmgr/broker_test.go
+++ b/checkmgr/broker_test.go
@@ -230,14 +230,12 @@ func TestGetBrokerCN(t *testing.T) {
 		submissionURL := apiclient.URLType("http://127.0.0.2:43191/blah/blah/blah")
 		cm := CheckManager{}
 
-		expectedError := errors.New("[ERROR] Unable to match URL host (127.0.0.2:43191) to Broker")
-
 		_, err := cm.getBrokerCN(&validBroker, submissionURL)
 		if err == nil {
-			t.Fatal("Expected error")
+			t.Fatal("expected error")
 		}
-		if err.Error() != expectedError.Error() {
-			t.Fatalf("Expected %v got '%v'", expectedError, err)
+		if err.Error() != "error, unable to match URL host (127.0.0.2:43191) to Broker" {
+			t.Fatalf("unexpected error (%s)", err)
 		}
 	}
 }
@@ -490,16 +488,14 @@ func TestGetBroker(t *testing.T) {
 		}
 		apih, err := apiclient.NewAPI(ac)
 		if err != nil {
-			t.Errorf("Expected no error, got '%v'", err)
+			t.Fatalf("unexpected error (%s)", err)
 		}
 		cm.apih = apih
 		cm.brokerID = 1
 
-		expectedError := errors.New("[ERROR] designated broker 1 [test broker] is invalid (not active, does not support required check type, or connectivity issue)")
-
 		_, err = cm.getBroker()
-		if err == nil || err.Error() != expectedError.Error() {
-			t.Errorf("Expected an '%#v' error, got '%#v'", expectedError, err)
+		if err == nil || err.Error() != "error, designated broker 1 [test broker] is invalid (not active, does not support required check type, or connectivity issue)" {
+			t.Fatalf("unexpected error (%s)", err)
 		}
 	}
 
@@ -518,14 +514,14 @@ func TestGetBroker(t *testing.T) {
 
 		apih, err := apiclient.NewAPI(ac)
 		if err != nil {
-			t.Errorf("Expected no error, got '%v'", err)
+			t.Fatalf("unexpected error (%s)", err)
 		}
 		cm.apih = apih
 		cm.brokerID = 2
 
 		_, err = cm.getBroker()
 		if err != nil {
-			t.Errorf("Expected no error, got '%v'", err)
+			t.Fatalf("unexpected error (%s)", err)
 		}
 	}
 

--- a/checkmgr/cert.go
+++ b/checkmgr/cert.go
@@ -7,8 +7,8 @@ package checkmgr
 import (
 	"crypto/x509"
 	"encoding/json"
-	"errors"
-	"fmt"
+
+	"github.com/pkg/errors"
 )
 
 // Default Circonus CA certificate
@@ -87,7 +87,7 @@ func (cm *CheckManager) fetchCert() ([]byte, error) {
 	}
 
 	if cadata.Contents == "" {
-		return nil, fmt.Errorf("[ERROR] Unable to find ca cert %+v", cadata)
+		return nil, errors.Errorf("error, unable to find ca cert %+v", cadata)
 	}
 
 	return []byte(cadata.Contents), nil

--- a/checkmgr/checkmgr.go
+++ b/checkmgr/checkmgr.go
@@ -51,6 +51,12 @@ const (
 	statusActive                 = "active"
 )
 
+// Logger facilitates use of any logger supporting the required methods
+// rather than just standard log package log.Logger
+type Logger interface {
+	Printf(string, ...interface{})
+}
+
 type MetricFilter struct {
 	// Type of rule 'allow' or 'deny'
 	Type string
@@ -123,7 +129,7 @@ type BrokerConfig struct {
 
 // Config options
 type Config struct {
-	Log   *log.Logger
+	Log   Logger
 	Debug bool
 
 	// Circonus API config
@@ -158,7 +164,7 @@ type BrokerCNType string
 // CheckManager settings
 type CheckManager struct {
 	enabled bool
-	Log     *log.Logger
+	Log     Logger
 	Debug   bool
 	apih    *apiclient.API
 
@@ -392,7 +398,7 @@ func (cm *CheckManager) Initialize() {
 			cm.initialized = true
 			cm.initializedmu.Unlock()
 		} else {
-			cm.Log.Printf("[WARN] error initializing trap %s", err.Error())
+			cm.Log.Printf("error initializing trap %s", err.Error())
 		}
 		return
 	}
@@ -406,7 +412,7 @@ func (cm *CheckManager) Initialize() {
 			cm.initialized = true
 			cm.initializedmu.Unlock()
 		} else {
-			cm.Log.Printf("[WARN] error initializing trap %s", err.Error())
+			cm.Log.Printf("error initializing trap %s", err.Error())
 		}
 		cm.apih.DisableExponentialBackoff()
 	}()

--- a/checkmgr/metrics.go
+++ b/checkmgr/metrics.go
@@ -99,7 +99,7 @@ func (cm *CheckManager) AddMetricTags(metricName string, tags []string, appendTa
 	}
 
 	if cm.Debug && action != "" {
-		cm.Log.Printf("[DEBUG] %s metric tag(s) %s %v\n", action, metricName, tags)
+		cm.Log.Printf("%s metric tag(s) %s %v\n", action, metricName, tags)
 	}
 
 	return tagsUpdated

--- a/circonus-gometrics.go
+++ b/circonus-gometrics.go
@@ -45,6 +45,12 @@ const (
 	defaultFlushInterval = "10s" // 10 * time.Second
 )
 
+// Logger facilitates use of any logger supporting the required methods
+// rather than just standard log package log.Logger
+type Logger interface {
+	Printf(string, ...interface{})
+}
+
 // Metric defines an individual metric
 type Metric struct {
 	Type  string      `json:"_type"`
@@ -56,7 +62,7 @@ type Metrics map[string]Metric
 
 // Config options for circonus-gometrics
 type Config struct {
-	Log             *log.Logger
+	Log             Logger
 	Debug           bool
 	ResetCounters   string // reset/delete counters on flush (default true)
 	ResetGauges     string // reset/delete gauges on flush (default true)
@@ -79,7 +85,7 @@ type prevMetrics struct {
 
 // CirconusMetrics state
 type CirconusMetrics struct {
-	Log   *log.Logger
+	Log   Logger
 	Debug bool
 
 	resetCounters   bool

--- a/counter.go
+++ b/counter.go
@@ -4,9 +4,7 @@
 
 package circonusgometrics
 
-import (
-	"fmt"
-)
+import "github.com/pkg/errors"
 
 // A Counter is a monotonically increasing unsigned integer.
 //
@@ -78,7 +76,7 @@ func (m *CirconusMetrics) GetCounterTest(metric string) (uint64, error) {
 		return val, nil
 	}
 
-	return 0, fmt.Errorf("Counter metric '%s' not found", metric)
+	return 0, errors.Errorf("counter metric '%s' not found", metric)
 
 }
 

--- a/gauge.go
+++ b/gauge.go
@@ -4,14 +4,12 @@
 
 package circonusgometrics
 
+import "github.com/pkg/errors"
+
 // A Gauge is an instantaneous measurement of a value.
 //
 // Use a gauge to track metrics which increase and decrease (e.g., amount of
 // free memory).
-
-import (
-	"fmt"
-)
 
 // GaugeWithTags sets a gauge metric with tags to a value
 func (m *CirconusMetrics) GaugeWithTags(metric string, tags Tags, val interface{}) {
@@ -102,7 +100,7 @@ func (m *CirconusMetrics) GetGaugeTest(metric string) (interface{}, error) {
 		return val, nil
 	}
 
-	return nil, fmt.Errorf("Gauge metric '%s' not found", metric)
+	return nil, errors.Errorf("Gauge metric '%s' not found", metric)
 }
 
 // SetGaugeFuncWithTags sets a gauge metric with tags to a function [called at flush interval]

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/circonus-labs/circonus-gometrics/v3
 
 require (
 	github.com/circonus-labs/circonusllhist v0.1.2
-	github.com/circonus-labs/go-apiclient v0.5.1
+	github.com/circonus-labs/go-apiclient v0.5.2
 	github.com/hashicorp/go-retryablehttp v0.5.0
 	github.com/pkg/errors v0.8.0
 	github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/circonus-labs/circonusllhist v0.1.2 h1:2jOJkxiDVNGbCtrwQwkZSvuguRLm3d
 github.com/circonus-labs/circonusllhist v0.1.2/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
 github.com/circonus-labs/go-apiclient v0.5.1 h1:TX45inyh1IJMpw8wruCQ7aB7pQ2frqARvA6wiobQj3g=
 github.com/circonus-labs/go-apiclient v0.5.1/go.mod h1:iFaYepsmBnyt+PC6YWpB9+5DDQdwogdO57JHLLi5Hzo=
+github.com/circonus-labs/go-apiclient v0.5.2 h1:80zezxpOYzfQWJPQViqoCyv3mmMIHwE9MrxTHNxnNDc=
+github.com/circonus-labs/go-apiclient v0.5.2/go.mod h1:624vxzSv6v6YnbEJ5o3xB2mjrqiPbSvyuo+s+nVabVo=
 github.com/hashicorp/go-cleanhttp v0.5.0 h1:wvCrVc9TjDls6+YGAF2hAifE1E5U1+b4tH6KdvN3Gig=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-retryablehttp v0.5.0 h1:aVN0FYnPwAgZI/hVzqwfMiM86ttcHTlQKbBVeVmXPIs=

--- a/histogram.go
+++ b/histogram.go
@@ -5,11 +5,11 @@
 package circonusgometrics
 
 import (
-	"fmt"
 	"sync"
 	"time"
 
 	"github.com/circonus-labs/circonusllhist"
+	"github.com/pkg/errors"
 )
 
 // Histogram measures the distribution of a stream of values.
@@ -146,7 +146,7 @@ func (m *CirconusMetrics) GetHistogramTest(metric string) ([]string, error) {
 		return hist.hist.DecStrings(), nil
 	}
 
-	return []string{""}, fmt.Errorf("Histogram metric '%s' not found", metric)
+	return []string{""}, errors.Errorf("Histogram metric '%s' not found", metric)
 }
 
 // Name returns the name from a histogram instance

--- a/metric_output.go
+++ b/metric_output.go
@@ -22,7 +22,7 @@ func (m *CirconusMetrics) packageMetrics() (map[string]*apiclient.CheckBundleMet
 	defer m.packagingmu.Unlock()
 
 	if m.Debug {
-		m.Log.Println("[DEBUG] Packaging metrics")
+		m.Log.Printf("packaging metrics\n")
 	}
 
 	counters, gauges, histograms, text := m.snapshot()
@@ -169,7 +169,7 @@ func (m *CirconusMetrics) Flush() {
 		m.submit(output, newMetrics)
 	} else {
 		if m.Debug {
-			m.Log.Println("[DEBUG] No metrics to send, skipping")
+			m.Log.Printf("no metrics to send, skipping\n")
 		}
 	}
 

--- a/submit_test.go
+++ b/submit_test.go
@@ -36,7 +36,7 @@ func TestSubmit(t *testing.T) {
 
 	cm, err := NewCirconusMetrics(cfg)
 	if err != nil {
-		t.Errorf("Expected no error, got '%v'", err)
+		t.Fatalf("unexpected error (%s)", err)
 	}
 
 	newMetrics := make(map[string]*apiclient.CheckBundleMetric)
@@ -59,7 +59,7 @@ func TestTrapCall(t *testing.T) {
 
 	cm, err := NewCirconusMetrics(cfg)
 	if err != nil {
-		t.Errorf("Expected no error, got '%v'", err)
+		t.Fatalf("unexpected error (%s)", err)
 	}
 
 	for !cm.check.IsReady() {
@@ -75,15 +75,15 @@ func TestTrapCall(t *testing.T) {
 
 	str, err := json.Marshal(output)
 	if err != nil {
-		t.Errorf("Expected no error, got '%v'", err)
+		t.Fatalf("unexpected error (%s)", err)
 	}
 
 	numStats, err := cm.trapCall(str)
 	if err != nil {
-		t.Errorf("Expected no error, got '%v'", err)
+		t.Fatalf("unexpected error (%s)", err)
 	}
 
 	if numStats != 1 {
-		t.Errorf("Expected 1, got %d", numStats)
+		t.Fatalf("Expected 1, got %d", numStats)
 	}
 }


### PR DESCRIPTION
* add: allow any log package with a `Printf` to be used
* upd: circonus-labs/go-apiclient v0.5.2 (for generic log support)
* upd: ensure only `Printf` is used for logging
* upd: migrate to errors package (`errors.Wrap` et al.)
* upd: error and log messages, remove explicit log level classifications from logging messages
* upd: OBSOLETE github.com/circonus-labs/v3/circonus-gometrics/api will be REMOVED --- USE **github.com/circonus-labs/go-apiclient**
