### PR TITLE
Allow histogram snapshot copy without reset

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,47 +2,66 @@
 
 
 [[projects]]
+  digest = "1:df3dc94b3fe86e95c1417202ee2fa5f63fb0903e063fff5ac81d440facb4c8cb"
   name = "github.com/circonus-labs/circonusllhist"
   packages = ["."]
-  revision = "5eb751da55c6d3091faf3861ec5062ae91fee9d0"
-  version = "v0.1.0"
+  pruneopts = ""
+  revision = "87d4d00b35adeefe4911ece727838749e0fab113"
+  version = "v0.1.3"
 
 [[projects]]
+  digest = "1:d6643f70ce124da435062a081e4997d65a282ccac0ff484020226a7bb1627fb5"
   name = "github.com/circonus-labs/go-apiclient"
   packages = [
     ".",
-    "config"
+    "config",
   ]
-  revision = "adb72bc548261c251e5ab341b695c3d678ed5c99"
-  version = "v0.5.0"
+  pruneopts = ""
+  revision = "e8c5a730387fbfd1b87b41fd00acc6ca46493704"
+  version = "v0.5.3"
 
 [[projects]]
+  digest = "1:05334858a0cfb538622a066e065287f63f42bee26a7fda93a789674225057201"
   name = "github.com/hashicorp/go-cleanhttp"
   packages = ["."]
+  pruneopts = ""
   revision = "e8ab9daed8d1ddd2d3c4efba338fe2eeae2e4f18"
   version = "v0.5.0"
 
 [[projects]]
-  branch = "master"
+  digest = "1:62327a30877f944b5fd23d130487731a3004b319ff1864daa677d7e554898cc1"
   name = "github.com/hashicorp/go-retryablehttp"
   packages = ["."]
-  revision = "e651d75abec6fbd4f2c09508f72ae7af8a8b7171"
+  pruneopts = ""
+  revision = "4502c0ecdaf0b50d857611af23831260f99be6bf"
+  version = "v0.5.0"
 
 [[projects]]
+  digest = "1:7365acd48986e205ccb8652cc746f09c8b7876030d53710ea6ef7d0bd0dcd7ca"
   name = "github.com/pkg/errors"
   packages = ["."]
+  pruneopts = ""
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
   version = "v0.8.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:eac3ff8988045e7700540ce20abeb0f7e858bed9f1914e24bb85d74e41670c6c"
   name = "github.com/tv42/httpunix"
   packages = ["."]
+  pruneopts = ""
   revision = "b75d8614f926c077e48d85f1f8f7885b758c6225"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "fdca12d2c0bbc1d3ab46ef0c7e00795efd0bf74bd1f03c66f53f61b99a27f12c"
+  input-imports = [
+    "github.com/circonus-labs/circonusllhist",
+    "github.com/circonus-labs/go-apiclient",
+    "github.com/circonus-labs/go-apiclient/config",
+    "github.com/hashicorp/go-retryablehttp",
+    "github.com/pkg/errors",
+    "github.com/tv42/httpunix",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -21,7 +21,7 @@
 
 
 [[constraint]]
-  branch = "master"
+  version = "0.5.0"
   name = "github.com/hashicorp/go-retryablehttp"
 
 [[constraint]]

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/circonus-labs/circonus-gometrics/v3
 
 require (
-	github.com/circonus-labs/circonusllhist v0.1.2
+	github.com/circonus-labs/circonusllhist v0.1.3
 	github.com/circonus-labs/go-apiclient v0.5.2
 	github.com/hashicorp/go-retryablehttp v0.5.0
 	github.com/pkg/errors v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
-github.com/circonus-labs/circonusllhist v0.1.2 h1:2jOJkxiDVNGbCtrwQwkZSvuguRLm3dZW2G2TyNltVN8=
-github.com/circonus-labs/circonusllhist v0.1.2/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
-github.com/circonus-labs/go-apiclient v0.5.1 h1:TX45inyh1IJMpw8wruCQ7aB7pQ2frqARvA6wiobQj3g=
-github.com/circonus-labs/go-apiclient v0.5.1/go.mod h1:iFaYepsmBnyt+PC6YWpB9+5DDQdwogdO57JHLLi5Hzo=
+github.com/circonus-labs/circonusllhist v0.1.3 h1:TJH+oke8D16535+jHExHj4nQvzlZrj7ug5D7I/orNUA=
+github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
 github.com/circonus-labs/go-apiclient v0.5.2 h1:80zezxpOYzfQWJPQViqoCyv3mmMIHwE9MrxTHNxnNDc=
 github.com/circonus-labs/go-apiclient v0.5.2/go.mod h1:624vxzSv6v6YnbEJ5o3xB2mjrqiPbSvyuo+s+nVabVo=
 github.com/hashicorp/go-cleanhttp v0.5.0 h1:wvCrVc9TjDls6+YGAF2hAifE1E5U1+b4tH6KdvN3Gig=

--- a/metric_output.go
+++ b/metric_output.go
@@ -272,9 +272,15 @@ func (m *CirconusMetrics) snapHistograms() map[string]*circonusllhist.Histogram 
 
 	for n, hist := range m.histograms {
 		hist.rw.Lock()
-		h[n] = hist.hist.CopyAndReset()
+		if m.resetHistograms {
+			h[n] = hist.hist.CopyAndReset()
+		} else {
+			h[n] = hist.hist.Copy()
+		}
+
 		hist.rw.Unlock()
 	}
+
 	if m.resetHistograms && len(h) > 0 {
 		m.histograms = make(map[string]*Histogram)
 	}

--- a/metric_output_test.go
+++ b/metric_output_test.go
@@ -525,3 +525,31 @@ func TestSnapshot(t *testing.T) {
 		t.Errorf("Expected 1, found %d", len(text))
 	}
 }
+
+func TestSnapshotWithoutHistogramReset(t *testing.T) {
+	t.Log("Testing util.snapshot with no histogram reset")
+
+	cm := &CirconusMetrics{}
+
+	cm.resetHistograms = false
+	cm.histograms = make(map[string]*Histogram)
+	cm.Timing("foo", 1)
+
+	if len(cm.histograms) != 1 {
+		t.Errorf("Expected 1, found %d", len(cm.histograms))
+	}
+
+	_, _, histograms, _ := cm.snapshot()
+
+	if len(histograms) != 1 {
+		t.Errorf("Expected 1, found %d", len(histograms))
+	}
+
+	if len(cm.histograms) != 1 {
+		t.Errorf("Expected 1, found %d", len(cm.histograms))
+	}
+
+	if len(cm.histograms["foo"].hist.DecStrings()) != 1 {
+		t.Errorf("Expected 1, found %d", len(cm.histograms))
+	}
+}


### PR DESCRIPTION
### This PR ([#91](https://github.com/circonus/goapi/pull/91)):
- Modifies the snapHistograms() method of the CirconusMetrics type to use the histogram Copy() function if resetHistograms is false, otherwise it will use the histogram CopyAndReset() function.
  - This change will allow internal data within all histograms not to reset if the ResetHistograms configuration option is set to false.
- Implements a unit test to verify this behavior is working.
- Updates go module and dep dependencies to use version 0.1.3 of https://github.com/circonus-labs/circonusllhist.  This version contains the histogram Copy() functionality.
- Version locks dep dependency for https://github.com/hashicorp/go-retryablehttp to the released version 0.5.0.
  - This ensures that the project builds and tests successfully whether go modules or dep is being used.