### PR TITLE
v3.0.0-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v3.0.0-beta
+
+* add: log deprecation notice on api calls
+* upd: dependency circonusllhist v0.1.2, go-apiclient v0.5.3
+* upd: `snapHistograms()` method to use the histogram `Copy()` if `resetHistograms` is false, otherwise uses `CopyAndReset()`
+
 # v3.0.0-alpha.5
 
 * add: allow any log package with a `Printf` to be used

--- a/api/api.go
+++ b/api/api.go
@@ -157,14 +157,14 @@ func New(ac *Config) (*API, error) {
 	}
 
 	a := &API{
-		apiURL:    apiURL,
-		key:       key,
-		app:       app,
-		accountID: acctID,
-		caCert:    ac.CACert,
-		tlsConfig: ac.TLSConfig,
-		Debug:     ac.Debug,
-		Log:       ac.Log,
+		apiURL:                apiURL,
+		key:                   key,
+		app:                   app,
+		accountID:             acctID,
+		caCert:                ac.CACert,
+		tlsConfig:             ac.TLSConfig,
+		Debug:                 ac.Debug,
+		Log:                   ac.Log,
 		useExponentialBackoff: false,
 	}
 
@@ -176,6 +176,8 @@ func New(ac *Config) (*API, error) {
 	if a.Log == nil {
 		a.Log = log.New(ioutil.Discard, "", log.LstdFlags)
 	}
+
+	a.Log.Printf("circonus-gometrics/api is DEPRECATED and will be removed - switch to github.com/circonus-labs/go-apiclient")
 
 	return a, nil
 }
@@ -223,6 +225,8 @@ func backoff(interval uint) float64 {
 
 // apiRequest manages retry strategy for exponential backoffs
 func (a *API) apiRequest(reqMethod string, reqPath string, data []byte) ([]byte, error) {
+	a.Log.Printf("circonus-gometrics/api is DEPRECATED and will be removed - switch to github.com/circonus-labs/go-apiclient")
+
 	backoffs := []uint{2, 4, 8, 16, 32}
 	attempts := 0
 	success := false

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/circonus-labs/circonus-gometrics/v3
 
 require (
 	github.com/circonus-labs/circonusllhist v0.1.3
-	github.com/circonus-labs/go-apiclient v0.5.2
+	github.com/circonus-labs/go-apiclient v0.5.3
 	github.com/hashicorp/go-retryablehttp v0.5.0
 	github.com/pkg/errors v0.8.0
 	github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/circonus-labs/circonusllhist v0.1.3 h1:TJH+oke8D16535+jHExHj4nQvzlZrj7ug5D7I/orNUA=
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
-github.com/circonus-labs/go-apiclient v0.5.2 h1:80zezxpOYzfQWJPQViqoCyv3mmMIHwE9MrxTHNxnNDc=
-github.com/circonus-labs/go-apiclient v0.5.2/go.mod h1:624vxzSv6v6YnbEJ5o3xB2mjrqiPbSvyuo+s+nVabVo=
+github.com/circonus-labs/go-apiclient v0.5.3 h1:xe0eJICrWwgjS2xz/nR1exS7DLbrGNLuvdvQFp2vcXA=
+github.com/circonus-labs/go-apiclient v0.5.3/go.mod h1:624vxzSv6v6YnbEJ5o3xB2mjrqiPbSvyuo+s+nVabVo=
 github.com/hashicorp/go-cleanhttp v0.5.0 h1:wvCrVc9TjDls6+YGAF2hAifE1E5U1+b4tH6KdvN3Gig=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-retryablehttp v0.5.0 h1:aVN0FYnPwAgZI/hVzqwfMiM86ttcHTlQKbBVeVmXPIs=


### PR DESCRIPTION
* add: log deprecation notice on api calls
* upd: dependency circonusllhist v0.1.2, go-apiclient v0.5.3
* upd: `snapHistograms()` method to use the histogram `Copy()` if `resetHistograms` is false, otherwise uses `CopyAndReset()`
