### PR TITLE
Remove v3 from checkmgr import path

### DIFF
--- a/circonus-gometrics.go
+++ b/circonus-gometrics.go
@@ -37,7 +37,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/circonus-labs/circonus-gometrics/v3/checkmgr"
+	"github.com/circonus-labs/circonus-gometrics/checkmgr"
 	"github.com/pkg/errors"
 )
 


### PR DESCRIPTION
### This PR ([#93](https://github.com/circonus-labs/circonus-gometrics/pull/93)):
- Removes the v3 segment from the import path of the checkmgr package in the circonus-gometrics.go file.
  - If it is important that this import path contain this, please close this PR, but the v3 branch builds and test without error in my environment with it removed.

The reason for removing this is that trying to vendor the v3 branch into another project will cause errors because of this import statement.  These errors will occur whether dep or go modules are used for package management.