### PR TITLE
v2.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v2.2.7
+
+* add: `search` (`*string`) attribute to graph datapoint
+* add: `cluster_ip` (`*string`) attribute to broker details
+
 # v2.2.6
 
 * fix: func signature to match go-retryablehttp update

--- a/api/broker.go
+++ b/api/broker.go
@@ -18,6 +18,7 @@ import (
 
 // BrokerDetail defines instance attributes
 type BrokerDetail struct {
+	ClusterIP    *string  `json:"cluster_ip"`               // string or null
 	CN           string   `json:"cn"`                       // string
 	ExternalHost *string  `json:"external_host"`            // string or null
 	ExternalPort uint16   `json:"external_port"`            // uint16

--- a/api/graph.go
+++ b/api/graph.go
@@ -60,6 +60,7 @@ type GraphDatapoint struct {
 	MetricName    string      `json:"metric_name,omitempty"`  // string
 	MetricType    string      `json:"metric_type,omitempty"`  // string
 	Name          string      `json:"name"`                   // string
+	Search        *string     `json:"search"`                 // string or null
 	Stack         *uint       `json:"stack"`                  // uint or null
 }
 


### PR DESCRIPTION
* add: `search` (`*string`) attribute to graph datapoint
* add: `cluster_ip` (`*string`) attribute to broker details
