### PR TITLE
add method for flush without resetting metrics

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -5,7 +5,7 @@
   branch = "master"
   name = "github.com/circonus-labs/circonusllhist"
   packages = ["."]
-  revision = "5eb751da55c6d3091faf3861ec5062ae91fee9d0"
+  revision = "ec08cde75a2939392fe7ef109066ae2078ca6b1e"
 
 [[projects]]
   branch = "master"

--- a/circonus-gometrics.go
+++ b/circonus-gometrics.go
@@ -360,6 +360,43 @@ func (m *CirconusMetrics) PromOutput() (*bytes.Buffer, error) {
 	return &b, err
 }
 
+// FlushMetricsNoReset flushes current metrics to a structure and returns it (does NOT send to Circonus).
+func (m *CirconusMetrics) FlushMetricsNoReset() *Metrics {
+	m.flushmu.Lock()
+	if m.flushing {
+		m.flushmu.Unlock()
+		return &Metrics{}
+	}
+
+	m.flushing = true
+	m.flushmu.Unlock()
+
+	// save values configured at startup
+	resetC := m.resetCounters
+	resetG := m.resetGauges
+	resetH := m.resetHistograms
+	resetT := m.resetText
+	// override Reset* to false for this call
+	m.resetCounters = false
+	m.resetGauges = false
+	m.resetHistograms = false
+	m.resetText = false
+
+	_, output := m.packageMetrics()
+
+	// restore previous values
+	m.resetCounters = resetC
+	m.resetGauges = resetG
+	m.resetHistograms = resetH
+	m.resetText = resetT
+
+	m.flushmu.Lock()
+	m.flushing = false
+	m.flushmu.Unlock()
+
+	return &output
+}
+
 // FlushMetrics flushes current metrics to a structure and returns it (does NOT send to Circonus)
 func (m *CirconusMetrics) FlushMetrics() *Metrics {
 	m.flushmu.Lock()

--- a/circonus-gometrics_test.go
+++ b/circonus-gometrics_test.go
@@ -531,6 +531,188 @@ func TestFlushMetrics(t *testing.T) {
 	}
 }
 
+func TestFlushMetricsNoReset(t *testing.T) {
+	cfg := &Config{}
+	cfg.CheckManager.Check.SubmissionURL = "none"
+	cfg.Interval = "0"
+
+	t.Log("Already flushing")
+	{
+		cm, err := NewCirconusMetrics(cfg)
+		if err != nil {
+			t.Errorf("Expected no error, got '%v'", err)
+		}
+
+		cm.flushing = true
+		metrics := cm.FlushMetricsNoReset()
+		if len(*metrics) != 0 {
+			t.Fatal("expected 0 metrics")
+		}
+	}
+
+	t.Log("No metrics")
+	{
+		cm, err := NewCirconusMetrics(cfg)
+		if err != nil {
+			t.Errorf("Expected no error, got '%v'", err)
+		}
+
+		metrics := cm.FlushMetricsNoReset()
+		if len(*metrics) != 0 {
+			t.Fatal("expected 0 metrics")
+		}
+	}
+
+	t.Log("counter")
+	{
+		cm, err := NewCirconusMetrics(cfg)
+		if err != nil {
+			t.Errorf("Expected no error, got '%v'", err)
+		}
+
+		cm.Set("foo", 30)
+
+		metrics := cm.FlushMetricsNoReset()
+		if len(*metrics) == 0 {
+			t.Fatal("expected 1 metric")
+		}
+
+		if m, mok := (*metrics)["foo"]; !mok {
+			t.Fatalf("'foo' not found in %v", metrics)
+		} else if m.Type != "L" {
+			t.Fatalf("'Type' not correct %v", m)
+		} else if m.Value.(uint64) != 30 {
+			t.Fatalf("'Value' not correct %v", m)
+		}
+
+		metrics = cm.FlushMetricsNoReset()
+		if len(*metrics) == 0 {
+			t.Fatal("expected 1 metric")
+		}
+
+		if m, mok := (*metrics)["foo"]; !mok {
+			t.Fatalf("'foo' not found in %v", metrics)
+		} else if m.Type != "L" {
+			t.Fatalf("'Type' not correct %v", m)
+		} else if m.Value.(uint64) != 30 {
+			t.Fatalf("'Value' not correct %v", m)
+		}
+	}
+
+	t.Log("gauge")
+	{
+		cm, err := NewCirconusMetrics(cfg)
+		if err != nil {
+			t.Errorf("Expected no error, got '%v'", err)
+		}
+
+		v := int64(30)
+		cm.SetGauge("foo", v)
+
+		metrics := cm.FlushMetricsNoReset()
+		if len(*metrics) == 0 {
+			t.Fatal("expected 1 metric")
+		}
+
+		if m, mok := (*metrics)["foo"]; !mok {
+			t.Fatalf("'foo' not found in %v", metrics)
+		} else if m.Type != "l" {
+			t.Fatalf("'Type' not correct %v", m)
+		} else if m.Value.(int64) != v {
+			t.Fatalf("'Value' not correct, expected %v got %v", v, m.Value)
+		}
+
+		metrics = cm.FlushMetricsNoReset()
+		if len(*metrics) == 0 {
+			t.Fatal("expected 1 metric")
+		}
+
+		if m, mok := (*metrics)["foo"]; !mok {
+			t.Fatalf("'foo' not found in %v", metrics)
+		} else if m.Type != "l" {
+			t.Fatalf("'Type' not correct %v", m)
+		} else if m.Value.(int64) != v {
+			t.Fatalf("'Value' not correct, expected %v got %v", v, m.Value)
+		}
+	}
+
+	t.Log("histogram")
+	{
+		cm, err := NewCirconusMetrics(cfg)
+		if err != nil {
+			t.Errorf("Expected no error, got '%v'", err)
+		}
+
+		cm.Timing("foo", 30.28)
+
+		metrics := cm.FlushMetricsNoReset()
+		if len(*metrics) == 0 {
+			t.Fatal("expected 1 metric")
+		}
+
+		if m, mok := (*metrics)["foo"]; !mok {
+			t.Fatalf("'foo' not found in %v", metrics)
+		} else if m.Type != "n" {
+			t.Fatalf("'Type' not correct %v", m)
+		} else if len(m.Value.([]string)) != 1 {
+			t.Fatal("expected 1 value")
+		} else if m.Value.([]string)[0] != "H[3.0e+01]=1" {
+			t.Fatalf("'Value' not correct %v", m)
+		}
+
+		metrics = cm.FlushMetricsNoReset()
+		if len(*metrics) == 0 {
+			t.Fatal("expected 1 metric")
+		}
+
+		if m, mok := (*metrics)["foo"]; !mok {
+			t.Fatalf("'foo' not found in %v", metrics)
+		} else if m.Type != "n" {
+			t.Fatalf("'Type' not correct %v", m)
+		} else if len(m.Value.([]string)) != 1 {
+			t.Fatalf("expected 1 value, got %d", len(m.Value.([]string)))
+		} else if m.Value.([]string)[0] != "H[3.0e+01]=1" {
+			t.Fatalf("'Value' not correct %v", m)
+		}
+	}
+
+	t.Log("text")
+	{
+		cm, err := NewCirconusMetrics(cfg)
+		if err != nil {
+			t.Errorf("Expected no error, got '%v'", err)
+		}
+
+		cm.SetText("foo", "bar")
+
+		metrics := cm.FlushMetricsNoReset()
+		if len(*metrics) == 0 {
+			t.Fatal("expected 1 metric")
+		}
+
+		if m, mok := (*metrics)["foo"]; !mok {
+			t.Fatalf("'foo' not found in %v", metrics)
+		} else if m.Type != "s" {
+			t.Fatalf("'Type' not correct %v", m)
+		} else if m.Value != "bar" {
+			t.Fatalf("'Value' not correct %v", m)
+		}
+
+		metrics = cm.FlushMetricsNoReset()
+		if len(*metrics) == 0 {
+			t.Fatal("expected 1 metric")
+		}
+
+		if m, mok := (*metrics)["foo"]; !mok {
+			t.Fatalf("'foo' not found in %v", metrics)
+		} else if m.Type != "s" {
+			t.Fatalf("'Type' not correct %v", m)
+		} else if m.Value != "bar" {
+			t.Fatalf("'Value' not correct %v", m)
+		}
+	}
+}
+
 func TestPromOutput(t *testing.T) {
 	cfg := &Config{}
 	cfg.CheckManager.Check.SubmissionURL = "none"

--- a/util.go
+++ b/util.go
@@ -102,7 +102,11 @@ func (m *CirconusMetrics) snapHistograms() map[string]*circonusllhist.Histogram 
 
 	for n, hist := range m.histograms {
 		hist.rw.Lock()
-		h[n] = hist.hist.CopyAndReset()
+		if m.resetHistograms {
+			h[n] = hist.hist.CopyAndReset()
+		} else {
+			h[n] = hist.hist.Copy()
+		}
 		hist.rw.Unlock()
 	}
 	if m.resetHistograms && len(h) > 0 {


### PR DESCRIPTION
Add a separate method that allows flushing without resetting metrics. Also fixes a case where `Config.ResetHistograms` wasn't being respected, which required a dependency version update to pull in `Histogram.Copy`.