### PR TITLE
v3.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v3.2.1
+
+* fix: internal log interface satisfies rh log interface no need to cast to log.Logger any longer
+
 # v3.2.0
 
 * add: accept category only tags

--- a/submit.go
+++ b/submit.go
@@ -135,7 +135,7 @@ func (m *CirconusMetrics) trapCall(payload []byte) (int, error) {
 	// retryablehttp only groks log or no log
 	// but, outputs everything as [DEBUG] messages
 	if m.Debug {
-		client.Logger = m.Log.(*log.Logger)
+		client.Logger = m.Log
 	} else {
 		client.Logger = log.New(ioutil.Discard, "", log.LstdFlags)
 	}


### PR DESCRIPTION
* fix: internal log interface satisfies rh log interface no need to cast to log.Logger any longer