### PR TITLE
v3.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# v3.4.2
+
+* upd: dependency (go-apiclient)
+* upd: clean up/normalize http client for httptrap requests
+* add: output full response from broker stats, filtered, and error if applicable in debug message
+* add: ability to send to clustered brokers behind LB which are not using a cert for a single CN
+* add: `SerialInit` option to initialize check serially
+* add: `GetBrokerTLSConfig` to retrieve broker tls configuration
+* add: `GetCheckBundle` for caching
+
 # v3.4.1
 
 * add: `DumpMetrics` config option, log payload sent to broker for debugging

--- a/checkmgr/broker.go
+++ b/checkmgr/broker.go
@@ -43,20 +43,21 @@ func (cm *CheckManager) getBroker() (*apiclient.Broker, error) {
 }
 
 // Get CN of Broker associated with submission_url to satisfy no IP SANS in certs
-func (cm *CheckManager) getBrokerCN(broker *apiclient.Broker, submissionURL apiclient.URLType) (string, error) {
+func (cm *CheckManager) getBrokerCN(broker *apiclient.Broker, submissionURL apiclient.URLType) (string, string, error) {
 	u, err := url.Parse(string(submissionURL))
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 
 	hostParts := strings.Split(u.Host, ":")
 	host := hostParts[0]
 
 	if net.ParseIP(host) == nil { // it's a non-ip string
-		return u.Host, nil
+		return u.Host, u.Host, nil
 	}
 
 	cn := ""
+	cnList := make([]string, 0, len(broker.Details))
 
 	for _, detail := range broker.Details {
 		// broker must be active
@@ -69,20 +70,23 @@ func (cm *CheckManager) getBrokerCN(broker *apiclient.Broker, submissionURL apic
 		// 2. set the tls.Config.ServerName to whatever that instance's CN is currently
 		// 3. cert will be valid for TLS conns (in theory)
 		if detail.IP != nil && *detail.IP == host {
-			cn = detail.CN
-			break
-		}
-		if detail.ExternalHost != nil && *detail.ExternalHost == host {
-			cn = detail.CN
-			break
+			if cn == "" {
+				cn = detail.CN
+			}
+			cnList = append(cnList, detail.CN)
+		} else if detail.ExternalHost != nil && *detail.ExternalHost == host {
+			if cn == "" {
+				cn = detail.CN
+			}
+			cnList = append(cnList, detail.CN)
 		}
 	}
 
 	if cn == "" {
-		return "", errors.Errorf("error, unable to match URL host (%s) to Broker", u.Host)
+		return "", "", errors.Errorf("error, unable to match URL host (%s) to Broker", u.Host)
 	}
 
-	return cn, nil
+	return cn, strings.Join(cnList, ","), nil
 
 }
 

--- a/checkmgr/broker.go
+++ b/checkmgr/broker.go
@@ -59,6 +59,11 @@ func (cm *CheckManager) getBrokerCN(broker *apiclient.Broker, submissionURL apic
 	cn := ""
 
 	for _, detail := range broker.Details {
+		// broker must be active
+		if detail.Status != statusActive {
+			continue
+		}
+
 		// certs are generated against the CN (in theory)
 		// 1. find the right broker instance with matching IP or external hostname
 		// 2. set the tls.Config.ServerName to whatever that instance's CN is currently

--- a/checkmgr/broker_test.go
+++ b/checkmgr/broker_test.go
@@ -209,7 +209,7 @@ func TestGetBrokerCN(t *testing.T) {
 		submissionURL := apiclient.URLType("http://127.0.0.1:43191/blah/blah/blah")
 		cm := CheckManager{}
 
-		_, err := cm.getBrokerCN(&validBroker, submissionURL)
+		_, _, err := cm.getBrokerCN(&validBroker, submissionURL)
 		if err != nil {
 			t.Fatalf("Expected no error, got %+v", err)
 		}
@@ -220,7 +220,7 @@ func TestGetBrokerCN(t *testing.T) {
 		submissionURL := apiclient.URLType("http://test.example.com:43191/blah/blah/blah")
 		cm := CheckManager{}
 
-		_, err := cm.getBrokerCN(&validBroker, submissionURL)
+		_, _, err := cm.getBrokerCN(&validBroker, submissionURL)
 		if err != nil {
 			t.Fatalf("Expected no error, got %+v", err)
 		}
@@ -231,7 +231,7 @@ func TestGetBrokerCN(t *testing.T) {
 		submissionURL := apiclient.URLType("http://127.0.0.2:43191/blah/blah/blah")
 		cm := CheckManager{}
 
-		_, err := cm.getBrokerCN(&validBroker, submissionURL)
+		_, _, err := cm.getBrokerCN(&validBroker, submissionURL)
 		if err == nil {
 			t.Fatal("expected error")
 		}

--- a/checkmgr/cert.go
+++ b/checkmgr/cert.go
@@ -53,6 +53,11 @@ func (cm *CheckManager) loadCACert() error {
 		return nil
 	}
 
+	if cm.brokerTLS != nil {
+		cm.certPool = cm.brokerTLS.RootCAs
+		return nil
+	}
+
 	cm.certPool = x509.NewCertPool()
 
 	var cert []byte

--- a/checkmgr/check.go
+++ b/checkmgr/check.go
@@ -233,11 +233,12 @@ func (cm *CheckManager) initializeTrapURL() error {
 
 	// used when sending as "ServerName" get around certs not having IP SANS
 	// (cert created with server name as CN but IP used in trap url)
-	cn, err := cm.getBrokerCN(broker, cm.trapURL)
+	cn, cnList, err := cm.getBrokerCN(broker, cm.trapURL)
 	if err != nil {
 		return err
 	}
 	cm.trapCN = BrokerCNType(cn)
+	cm.trapCNList = cnList
 
 	if cm.enabled {
 		u, err := url.Parse(string(cm.trapURL))

--- a/checkmgr/checkmgr.go
+++ b/checkmgr/checkmgr.go
@@ -181,6 +181,7 @@ type CheckManager struct {
 	checkDisplayName      CheckDisplayNameType   // check
 	trapURL               apiclient.URLType      // state
 	trapCN                BrokerCNType           // state
+	trapCNList            string                 // state
 	checkMetricFilters    []MetricFilter         // check
 	checkTags             apiclient.TagType      // check
 	brokerSelectTag       apiclient.TagType      // broker
@@ -504,7 +505,8 @@ func (cm *CheckManager) GetSubmissionURL() (*Trap, error) {
 				InsecureSkipVerify: true, //nolint:gosec
 				VerifyConnection: func(cs tls.ConnectionState) error {
 					commonName := cs.PeerCertificates[0].Subject.CommonName
-					if commonName != cs.ServerName {
+					// if commonName != cs.ServerName {
+					if !strings.Contains(cm.trapCNList, commonName) {
 						return fmt.Errorf("invalid certificate name %q, expected %q", commonName, cs.ServerName)
 					}
 					opts := x509.VerifyOptions{

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/circonus-labs/circonus-gometrics/v3
 go 1.14
 
 require (
-	github.com/circonus-labs/go-apiclient v0.7.13
+	github.com/circonus-labs/go-apiclient v0.7.14
 	github.com/hashicorp/go-retryablehttp v0.6.8
 	github.com/openhistogram/circonusllhist v0.2.1
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/circonus-labs/go-apiclient v0.7.13 h1:jiZw0DXsP06WxPFvmFNpcYFfQxC0GiYIVzC78lbCVXw=
-github.com/circonus-labs/go-apiclient v0.7.13/go.mod h1:RFgkvdYEkimzgu3V2vVYlS1bitjOz1SF6uw109ieNeY=
+github.com/circonus-labs/go-apiclient v0.7.14 h1:SWES4wUaNNCXuQJeKQ5EC+D/eeARFYbPjPMfjWAj+8M=
+github.com/circonus-labs/go-apiclient v0.7.14/go.mod h1:RFgkvdYEkimzgu3V2vVYlS1bitjOz1SF6uw109ieNeY=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=

--- a/metric_output.go
+++ b/metric_output.go
@@ -22,9 +22,9 @@ func (m *CirconusMetrics) packageMetrics() (map[string]*apiclient.CheckBundleMet
 	m.packagingmu.Lock()
 	defer m.packagingmu.Unlock()
 
-	if m.Debug {
-		m.Log.Printf("packaging metrics\n")
-	}
+	// if m.Debug {
+	// 	m.Log.Printf("packaging metrics\n")
+	// }
 
 	ts := makeTimestamp(time.Now())
 
@@ -216,9 +216,9 @@ func (m *CirconusMetrics) Flush() {
 
 	if len(output) > 0 {
 		m.submit(output, newMetrics)
-	} else if m.Debug {
+	} /* else if m.Debug {
 		m.Log.Printf("no metrics to send, skipping\n")
-	}
+	}*/
 
 	m.flushmu.Lock()
 	m.flushing = false

--- a/submit_test.go
+++ b/submit_test.go
@@ -78,12 +78,12 @@ func TestTrapCall(t *testing.T) {
 		t.Fatalf("unexpected error (%s)", err)
 	}
 
-	numStats, err := cm.trapCall(str)
+	result, err := cm.trapCall(str)
 	if err != nil {
 		t.Fatalf("unexpected error (%s)", err)
 	}
 
-	if numStats != 1 {
-		t.Fatalf("Expected 1, got %d", numStats)
+	if result.Stats != 1 {
+		t.Fatalf("Expected 1, got %#v", result)
 	}
 }


### PR DESCRIPTION
* upd: dependency (go-apiclient)
* upd: clean up/normalize http client for httptrap requests
* add: output full response from broker stats, filtered, and error if applicable in debug message
* add: ability to send to clustered brokers behind LB which are not using a cert for a single CN
* add: `SerialInit` option to initialize check serially
* add: `GetBrokerTLSConfig` to retrieve broker tls configuration
* add: `GetCheckBundle` for caching
